### PR TITLE
Sharpen profile and add statistics tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Statistical modelling, production AI, decision systems, and reproducible researc
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md"><img src="https://img.shields.io/badge/Statistics-30363D?style=for-the-badge" alt="Statistics" /></a>
 </div>
 
 I build data and AI systems where the difficult part starts after model fitting: defining the estimand, validating uncertainty, detecting distribution shift, choosing the operating policy, and keeping the result reproducible in production. My work moves between statistical modelling, machine learning, research software, production AI, optimisation, and applied quantitative research.
@@ -16,6 +17,13 @@ I build data and AI systems where the difficult part starts after model fitting:
 **Selected delivery outcomes:** 80% reduction in reporting costs · 30% reduction in analytics processing time · €500K reduction in inventory value through forecasting and operational optimisation.
 
 The common thread is simple: start from the problem and the evidence, use the least complicated model that answers it well, and make the resulting claim inspectable.
+
+<p align="center">
+  <img src="data_has_a_better_idea.png"
+       alt="Poster with the phrase 'Data has a better idea'"
+       title="Data has a better idea"
+       width="65%" />
+</p>
 
 ---
 
@@ -60,6 +68,8 @@ The common thread is simple: start from the problem and the evidence, use the le
 | :-- | :-- |
 | **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>Curated production, research, modelling, optimisation, and data-engineering work. | **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The modelling toolbox, technical stack, and methods I use by problem type. |
 | **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current programmes, research themes, reproducibility standards, and collaboration interests. | **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. |
+
+**[Statistics →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md)** — GitHub activity and profile widgets kept separate from the technical portfolio.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Diogo Ribeiro
 
-**Lead Data Scientist · AI Engineer · Professor · Mathematical Engineer**  
-20+ years in quantitative, analytical, and technical roles · United Kingdom & Portugal · Python (typed, NumPy-first)
+**Lead Data Scientist · Mathematician · AI/ML Engineer · Researcher & Lecturer**  
+Statistical modelling, production AI, decision systems, and reproducible research · Python-first
 
 <div align="center">
   <img src="https://img.shields.io/badge/Home-1F6FEB?style=for-the-badge" alt="Home (current page)" />
@@ -11,99 +11,75 @@
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
 </div>
 
-> "Knowledge is knowing a tomato is a fruit; wisdom is not putting it in a fruit salad."
-> — Miles Kington
+I build data and AI systems where the difficult part starts after model fitting: defining the estimand, validating uncertainty, detecting distribution shift, choosing the operating policy, and keeping the result reproducible in production. My work moves between statistical modelling, machine learning, research software, production AI, optimisation, and applied quantitative research.
 
-I build end-to-end machine learning, AI, and data science systems — from data pipelines and statistical modelling through evaluation, deployment, monitoring, and business-facing decision support. The work combines mathematical and statistical depth with production engineering, with particular attention to model validation, uncertainty, interpretability, drift, and operational reliability. Alongside it I run reproducible research pipelines that turn open data into auditable evidence; when a method I need is missing from the Python ecosystem, I build it, validate it against the reference implementation, and publish it.
+**Selected delivery outcomes:** 80% reduction in reporting costs · 30% reduction in analytics processing time · €500K reduction in inventory value through forecasting and operational optimisation.
 
-**Delivered outcomes:** 80% reduction in reporting costs · 30% reduction in analytics processing time · €500K reduction in inventory value through forecasting and operational optimisation.
-
-I work across research, engineering, and business-facing delivery — translating complex, often messy problems into systems that can be evaluated, explained, deployed, and used to make decisions. Lean models, robust software practice, results you can reproduce and defend.
-
-<p align="center">
-  <img src="data_has_a_better_idea.png"
-       alt="Poster with the phrase 'Data has a better idea'"
-       title="Data has a better idea"
-       width="65%" />
-</p>
-
----
-
-## Where to Go
-
-|  |  |
-| :-- | :-- |
-| **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>~70 curated repositories across AI, ML engineering, data engineering, statistics, economics, optimisation, and tooling — plus this year's highlights. | **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The domains I work in, the stack I build with, and the model families I reach for, by task. |
-| **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current focus, research themes, how the programmes are built, and what I am open to collaborating on. | **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>Courses at ESMAD (Instituto Politécnico do Porto), seminars, and workshop material. |
-
----
-
-## What I Do
-
-- **Production AI & LLM systems** — RAG, agents, MCP servers, structured outputs, and guardrails, with evaluation, observability, and CI from the start.
-- **Forecasting, anomaly detection & reliability under shift** — classical to foundation-model time series, conformal intervals, drift monitoring, and models that abstain instead of guessing.
-- **Statistical modelling & causal inference** — calibration and uncertainty, class imbalance, cost-sensitive thresholds, and honest model selection under real-world noise.
-- **Econometrics & policy research** — panel and causal models, event studies, synthetic control, csQCA/fsQCA, and Monte Carlo over open economic data.
-- **Optimisation & decision systems** — MILP unit commitment, inventory and replenishment policy, scheduling under uncertainty, cost-weighted operating thresholds.
-- **ML engineering & delivery** — data pipelines, real-time analytics, serving, monitoring, and drift detection — applied across sensor and IoT modelling, healthcare analytics, and NLP.
-- **Research software** — methods missing from the Python ecosystem: typed, tested, validated against the reference implementation, and published with a DOI.
-
-→ Full stack, domains, and model families on **[Methods](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**.
+The common thread is simple: start from the problem and the evidence, use the least complicated model that answers it well, and make the resulting claim inspectable.
 
 ---
 
 ## Selected Work
 
-- **[feedback-intelligence-agent](https://github.com/DiogoRibeiro7/feedback-intelligence-agent)** — Production-style RAG: a customer feedback intelligence agent with FastAPI, evaluation, observability, and CI.
-- **[hf-data-agent](https://github.com/DiogoRibeiro7/hf-data-agent)** — Internal data agent where UI, HTTP, MCP, and Slack funnel into one Agent API, grounding an open-source model in a company knowledge base.
-- **[clinic-forecasting-platform](https://github.com/DiogoRibeiro7/clinic-forecasting-platform)** — Healthcare demand forecasting: a 13-model benchmark with conformal intervals, rolling-origin backtesting, and FastAPI serving.
-- **[setqca](https://github.com/DiogoRibeiro7/setqca-python)** — Native, typed Python csQCA/fsQCA with exact Boolean minimisation — not an R wrapper. Matches the reference R package; on PyPI with a DOI.
-- **[portugal-public-pension-financing](https://github.com/DiogoRibeiro7/portugal-public-pension-financing)** — How the public pension promise was actually financed, separating legal obligations, cash accounting, and actuarial liabilities before calling anything a deficit.
-- **[bmssp](https://github.com/DiogoRibeiro7/bmssp)** ⭐ — Deterministic single-source shortest paths via a BMSSP-style divide-and-conquer design (typed, tested).
+| Project | What it demonstrates |
+| :-- | :-- |
+| **[feedback-intelligence-agent](https://github.com/DiogoRibeiro7/feedback-intelligence-agent)** | Production-style RAG with FastAPI, retrieval evaluation, observability, and CI. |
+| **[genSurvPy](https://github.com/DiogoRibeiro7/genSurvPy)** | Typed survival-simulation software on PyPI: twelve model families, a general multistate engine, explicit ground truth, documentation, and parameter-recovery checks. |
+| **[behavioral-sensing-research](https://github.com/DiogoRibeiro7/behavioral-sensing-research)** | Failure-aware multimodal sensing: sensor health, uncertainty-aware fusion, abstention, adaptive baselines, change detection, and reproducible simulation experiments. |
+| **[clinic-forecasting-platform](https://github.com/DiogoRibeiro7/clinic-forecasting-platform)** | Healthcare demand forecasting with a 13-model benchmark, rolling-origin backtesting, conformal intervals, serving, and monitoring. |
+| **[setqca](https://github.com/DiogoRibeiro7/setqca-python)** | Native typed Python csQCA/fsQCA with exact Boolean minimisation, validated against the reference R implementation and published with a DOI. |
+| **[qwen-text2sql-lab](https://github.com/DiogoRibeiro7/qwen-text2sql-lab)** | Controlled LoRA/QLoRA adaptation of Qwen for text-to-SQL, evaluated by execution accuracy against the target database rather than string overlap. |
 
-**Live dashboards:** [Portugal Economic Indicators](https://portugal-econ-dashboard.vercel.app/) · [NASDAQ Stock Analytics](https://nasdaq-dashboard-sigma.vercel.app/)
-
-→ The full catalogue and this year's highlights on **[Projects](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**.
+→ The broader catalogue is on **[Projects](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**.
 
 ---
 
-## Right Now
+## Current Work
 
-- Production RAG and agentic systems with evaluation, observability, and CI baked in — MCP as a first-class entrypoint alongside HTTP and Slack
-- Portuguese public finance and official statistics under audit: what the general-government balance, the pension promise, and a headline index actually measure
-- Reliability under distribution shift: conformal coverage with explicit abstention, survival-model drift monitoring, cost-weighted operating thresholds
-- Configurational methods in Python: a native csQCA/fsQCA implementation validated against R, and survey-design-aware applications across the EU-27
+- **Failure-aware behavioural sensing** — separating sensor failure, missing evidence, occupancy ambiguity, and genuine behavioural change before an alert is allowed to mean anything. The current paper programme lives in [behavioral-sensing-research](https://github.com/DiogoRibeiro7/behavioral-sensing-research/tree/develop/papers/failure-aware-multimodal-behavioural-sensing).
+- **Forecast → decision systems** — probabilistic demand forecasts evaluated by the decisions they support, including constrained fleet allocation on real mobility data in [ds-projects-portfolio](https://github.com/DiogoRibeiro7/ds-projects-portfolio/tree/main/projects/mobility_demand_optimization).
+- **Survival-model evaluation** — using known-truth simulation to study when ranking metrics, probability accuracy, censoring, and model misspecification tell different stories, built on [genSurvPy](https://github.com/DiogoRibeiro7/genSurvPy).
+- **Reproducible economic and policy research** — treating definitions, measurement boundaries, identification, and provenance as part of the model rather than preprocessing details.
 
-→ The full set of active threads on **[Research](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md#current-focus)**.
+→ More active research threads on **[Research](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md#current-focus)**.
+
+---
+
+## How I Work
+
+- **Model the question before the algorithm.** Define the estimand, failure modes, constraints, and decision rule first.
+- **Use strong baselines.** Classical statistical and mathematical models are often the right starting point; complexity has to earn its place empirically.
+- **Treat reliability as part of modelling.** Calibration, uncertainty, leakage, missingness, drift, abstention, and operating thresholds belong in the design, not in an appendix.
+- **Make claims reproducible.** Typed code, tests, CI, frozen configurations, provenance, and machine-readable outputs are part of the research and engineering contract.
+
+---
+
+## Explore
+
+|  |  |
+| :-- | :-- |
+| **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>Curated production, research, modelling, optimisation, and data-engineering work. | **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The modelling toolbox, technical stack, and methods I use by problem type. |
+| **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current programmes, research themes, reproducibility standards, and collaboration interests. | **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. |
 
 ---
 
 ## Work With Me
 
-I teach mathematics and data subjects at **ESMAD (Instituto Politécnico do Porto)** and run seminars on MLOps, streaming analytics, experimentation, and forecasting — see **[Teaching](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**.
+I teach mathematics and data subjects at **ESMAD (Instituto Politécnico do Porto)** and work across statistical modelling, production AI, forecasting, optimisation, research software, and reproducible applied research.
 
-Open to collaboration on production AI, reproducible policy research, robust time series, and forecast-to-decision systems — see **[Research](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md#open-to-collaboration-on)**. When reaching out, include a short note on your use case, constraints, and timeline so we can assess fit quickly.
+For collaboration, research, or professional enquiries, a short note describing the problem, constraints, and expected outcome is the best starting point.
 
 <div align="center">
   <a href="mailto:diogo.debastos.ribeiro@gmail.com">
     <img src="https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Email">
   </a>
   <a href="https://www.linkedin.com/in/diogo-ribeiro-9094604a/">
-    <img src="https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" />
+    <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" />
   </a>
   <a href="https://medium.com/@neverforget-1975">
     <img src="https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white" alt="Medium" />
   </a>
   <a href="https://dev.to/diogoribeiro7">
     <img src="https://img.shields.io/badge/dev.to-0A0A0A?style=for-the-badge&logo=dev.to&logoColor=white" alt="Dev.to" />
-  </a>
-</div>
-
-<div align="center">
-  <a href="https://user-badge.committers.top/portugal_private/DiogoRibeiro7">
-    <img src="https://user-badge.committers.top/portugal_private/DiogoRibeiro7.svg" alt="committers.top badge"/>
-  </a>
-  <a href="https://github.com/ryo-ma/github-profile-trophy">
-    <img src="https://github-profile-trophy-unserori.vercel.app/?username=DiogoRibeiro7&column=3&no-frame=true&theme=algolia" alt="Trophy" />
   </a>
 </div>

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -1,0 +1,28 @@
+<div align="center">
+  <a href="https://github.com/DiogoRibeiro7"><img src="https://img.shields.io/badge/Home-30363D?style=for-the-badge" alt="Home" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md"><img src="https://img.shields.io/badge/Projects-30363D?style=for-the-badge" alt="Projects" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
+  <img src="https://img.shields.io/badge/Statistics-1F6FEB?style=for-the-badge" alt="Statistics (current page)" />
+</div>
+
+---
+
+# Statistics
+
+GitHub activity and profile widgets are kept here so the main profile can stay focused on technical work, research, and delivered outcomes.
+
+<div align="center">
+  <a href="https://user-badge.committers.top/portugal_private/DiogoRibeiro7">
+    <img src="https://user-badge.committers.top/portugal_private/DiogoRibeiro7.svg" alt="committers.top badge"/>
+  </a>
+</div>
+
+<br>
+
+<div align="center">
+  <a href="https://github.com/ryo-ma/github-profile-trophy">
+    <img src="https://github-profile-trophy-unserori.vercel.app/?username=DiogoRibeiro7&column=3&no-frame=true&theme=algolia" alt="GitHub profile trophies" />
+  </a>
+</div>


### PR DESCRIPTION
## Summary

Refocus the GitHub profile landing page around evidence rather than breadth, while preserving the visual poster and moving profile widgets into their own Statistics page.

### Changes
- strengthen the opening identity around mathematics, statistical modelling, production AI, decision systems, and reproducible research
- replace the longer catalogue-style landing page with six selected proof-of-work projects
- surface current work in failure-aware sensing, forecast-to-decision systems, survival-model evaluation, and reproducible economic research
- add a concise "How I Work" section covering estimands, baselines, reliability, and reproducibility
- restore the `data_has_a_better_idea.png` poster on the homepage
- add a new `STATISTICS.md` tab
- move the committers.top and GitHub trophy widgets to the Statistics page instead of removing them
- keep Projects, Methods, Research, and Teaching as the detailed navigation layer

The homepage now carries the technical/professional signal; Statistics carries activity/profile widgets separately.