### PR TITLE
Add curated featured-projects layer

### DIFF
--- a/FEATURED.md
+++ b/FEATURED.md
@@ -1,0 +1,48 @@
+<div align="center">
+  <a href="https://github.com/DiogoRibeiro7"><img src="https://img.shields.io/badge/Home-30363D?style=for-the-badge" alt="Home" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md"><img src="https://img.shields.io/badge/Projects-30363D?style=for-the-badge" alt="Projects" /></a>
+  <img src="https://img.shields.io/badge/Featured-1F6FEB?style=for-the-badge" alt="Featured (current page)" />
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md"><img src="https://img.shields.io/badge/Statistics-30363D?style=for-the-badge" alt="Statistics" /></a>
+</div>
+
+---
+
+# Featured Projects
+
+A short list for reviewers who want the strongest cross-section of my work without browsing the full repository catalogue.
+
+| Project | Area | Why inspect it |
+| :-- | :-- | :-- |
+| **[feedback-intelligence-agent](https://github.com/DiogoRibeiro7/feedback-intelligence-agent)** | Production AI | RAG with FastAPI, retrieval evaluation, observability, and CI rather than a notebook-only demonstration. |
+| **[qwen-text2sql-lab](https://github.com/DiogoRibeiro7/qwen-text2sql-lab)** | LLM adaptation | Controlled LoRA/QLoRA study evaluated by execution accuracy against the target database. |
+| **[behavioral-sensing-research](https://github.com/DiogoRibeiro7/behavioral-sensing-research)** | Statistical sensing | Failure-aware multimodal inference with sensor health, missing-evidence semantics, abstention, adaptive baselines, and reproducible research experiments. |
+| **[genSurvPy](https://github.com/DiogoRibeiro7/genSurvPy)** | Research software | Typed survival-data simulation on PyPI with twelve model families, a general multistate engine, explicit latent truth, documentation, CI, and parameter-recovery checks. |
+| **[setqca](https://github.com/DiogoRibeiro7/setqca-python)** | Statistical methods | Native typed Python csQCA/fsQCA with exact Boolean minimisation and validation against the reference R implementation. |
+| **[clinic-forecasting-platform](https://github.com/DiogoRibeiro7/clinic-forecasting-platform)** | Forecasting & MLOps | Thirteen-model healthcare forecasting benchmark with rolling-origin evaluation, conformal intervals, serving, and monitoring. |
+| **[transaction-risk-lakehouse](https://github.com/DiogoRibeiro7/transaction-risk-lakehouse)** | Data engineering | Production-style PySpark lakehouse for transaction risk, fraud modelling, and temporal validation. |
+| **[oisst-fourier-neural-operator](https://github.com/DiogoRibeiro7/oisst-fourier-neural-operator)** | Scientific ML | Real NOAA sea-surface-temperature experiment asking when a Fourier Neural Operator actually beats persistence and at which spatial scales. |
+| **[energy-system-simulator](https://github.com/DiogoRibeiro7/energy-system-simulator)** | Optimisation | Unit commitment, storage, hydro, demand response, imports, and distribution constraints in an explicit decision model. |
+| **[portugal-public-pension-financing](https://github.com/DiogoRibeiro7/portugal-public-pension-financing)** | Empirical research | Auditable public-finance research separating legal obligations, accounting flows, actuarial liabilities, and counterfactual financing regimes. |
+| **[short-rate-anomaly-regimes](https://github.com/DiogoRibeiro7/short-rate-anomaly-regimes)** | Quantitative finance | Replication-grade asset-pricing research with frozen artifacts, provenance labels, and automated table/source consistency checks. |
+| **[bmssp](https://github.com/DiogoRibeiro7/bmssp)** | Algorithms | Deterministic single-source shortest paths via a typed and tested BMSSP-style divide-and-conquer implementation. |
+
+## By reviewer interest
+
+**Production AI / LLMs:** start with `feedback-intelligence-agent`, then `qwen-text2sql-lab`.
+
+**Statistics / research software:** start with `genSurvPy`, `setqca`, and `behavioral-sensing-research`.
+
+**Forecasting / decision science:** start with `clinic-forecasting-platform` and `energy-system-simulator`.
+
+**Data engineering / MLOps:** start with `transaction-risk-lakehouse`.
+
+**Scientific computing / mathematics:** start with `oisst-fourier-neural-operator` and `bmssp`.
+
+**Economics / quantitative research:** start with `portugal-public-pension-financing` and `short-rate-anomaly-regimes`.
+
+---
+
+The broader catalogue, including private active programmes, dashboards, and specialist libraries, remains on **[Projects](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Statistical modelling, production AI, decision systems, and reproducible researc
 <div align="center">
   <img src="https://img.shields.io/badge/Home-1F6FEB?style=for-the-badge" alt="Home (current page)" />
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md"><img src="https://img.shields.io/badge/Projects-30363D?style=for-the-badge" alt="Projects" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md"><img src="https://img.shields.io/badge/Featured-30363D?style=for-the-badge" alt="Featured" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
@@ -38,7 +39,7 @@ The common thread is simple: start from the problem and the evidence, use the le
 | **[setqca](https://github.com/DiogoRibeiro7/setqca-python)** | Native typed Python csQCA/fsQCA with exact Boolean minimisation, validated against the reference R implementation and published with a DOI. |
 | **[qwen-text2sql-lab](https://github.com/DiogoRibeiro7/qwen-text2sql-lab)** | Controlled LoRA/QLoRA adaptation of Qwen for text-to-SQL, evaluated by execution accuracy against the target database rather than string overlap. |
 
-→ The broader catalogue is on **[Projects](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**.
+→ **[Featured](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md)** gives a 12-project cross-section by reviewer interest. The broader catalogue remains on **[Projects](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**.
 
 ---
 
@@ -66,10 +67,9 @@ The common thread is simple: start from the problem and the evidence, use the le
 
 |  |  |
 | :-- | :-- |
-| **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>Curated production, research, modelling, optimisation, and data-engineering work. | **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The modelling toolbox, technical stack, and methods I use by problem type. |
-| **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current programmes, research themes, reproducibility standards, and collaboration interests. | **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. |
-
-**[Statistics →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md)** — GitHub activity and profile widgets kept separate from the technical portfolio.
+| **[Featured →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md)**<br>Twelve flagship projects, grouped by what a reviewer is looking for. | **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>The broader catalogue across production, research, modelling, optimisation, and data engineering. |
+| **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The modelling toolbox, technical stack, and methods I use by problem type. | **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current programmes, research themes, reproducibility standards, and collaboration interests. |
+| **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. | **[Statistics →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md)**<br>GitHub activity and profile widgets kept separate from the technical portfolio. |
 
 ---
 


### PR DESCRIPTION
## Summary

Add a concise reviewer-oriented layer between the profile homepage and the full project catalogue.

### Changes
- add `FEATURED.md` with 12 flagship projects spanning production AI, LLM adaptation, statistical sensing, research software, forecasting, data engineering, scientific ML, optimisation, empirical research, quantitative finance, and algorithms
- group the flagship set by reviewer interest so hiring managers and collaborators can jump directly to the most relevant work
- add a Featured tab to the homepage navigation
- link the existing Selected Work section to the new curated page while keeping `PROJECTS.md` as the broad catalogue
- preserve the poster and Statistics tab introduced in PR #7

This avoids rewriting or shrinking the existing 30 KB project catalogue while making the strongest work much faster to discover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a curated `FEATURED.md` page that highlights 12 flagship projects grouped by reviewer interest, so hiring managers and collaborators can jump to the most relevant work without browsing the full catalogue. Homepage navigation and the Selected Work section now link to the new page; the original `PROJECTS.md` catalogue stays intact.

<sup>Written for commit ea57b35b78ec8bb39a87aa3c13b8ef67b7771cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

