### PR TITLE
Add self-updating topic statistics widget

### DIFF
--- a/.github/workflows/topic-statistics.yml
+++ b/.github/workflows/topic-statistics.yml
@@ -1,0 +1,40 @@
+name: Topic statistics
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - PROJECTS.md
+      - scripts/generate_topic_statistics.py
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-widget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate topic statistics
+        run: python scripts/generate_topic_statistics.py
+
+      - name: Commit updated widget
+        run: |
+          if git diff --quiet -- assets/topic-statistics.svg; then
+            echo "Topic statistics are already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/topic-statistics.svg
+          git commit -m "docs: refresh topic statistics"
+          git push

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -1,5 +1,6 @@
 <div align="center">
   <a href="https://github.com/DiogoRibeiro7"><img src="https://img.shields.io/badge/Home-30363D?style=for-the-badge" alt="Home" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md"><img src="https://img.shields.io/badge/Featured-30363D?style=for-the-badge" alt="Featured" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md"><img src="https://img.shields.io/badge/Projects-30363D?style=for-the-badge" alt="Projects" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
@@ -11,7 +12,19 @@
 
 # Statistics
 
-GitHub activity and profile widgets are kept here so the main profile can stay focused on technical work, research, and delivered outcomes.
+A quantitative view of the areas represented in the curated project catalogue, followed by GitHub activity/profile widgets.
+
+## Topics I Work On
+
+<p align="center">
+  <img src="assets/topic-statistics.svg" alt="Bar chart showing the distribution of curated projects across the topics Diogo works on" width="100%" />
+</p>
+
+The chart is generated from the second-level topic sections in [`PROJECTS.md`](PROJECTS.md). Each listed project contributes one entry to its section, including explicitly marked private projects. The SVG is regenerated automatically whenever the project catalogue or generator changes.
+
+---
+
+## GitHub Activity
 
 <div align="center">
   <a href="https://user-badge.committers.top/portugal_private/DiogoRibeiro7">

--- a/assets/topic-statistics.svg
+++ b/assets/topic-statistics.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 820 464" role="img" aria-labelledby="title desc">
+<title id="title">Project topics</title>
+<desc id="desc">Distribution of 87 curated project entries across technical and research topics.</desc>
+<style>
+text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#c9d1d9}.muted{fill:#8b949e}.label{font-size:14px}.value{font-size:13px;font-weight:600}.title{font-size:20px;font-weight:700}.subtitle{font-size:13px}.track{fill:#21262d}.bar{fill:#58a6ff}@media (prefers-color-scheme: light){text{fill:#24292f}.muted{fill:#57606a}.track{fill:#d8dee4}.bar{fill:#0969da}}
+</style>
+<text x="24" y="30" class="title">Topics I work on</text>
+<text x="24" y="52" class="subtitle muted">87 curated project entries · generated from PROJECTS.md</text>
+<text x="24" y="88" class="label">AI &amp; LLM systems</text><rect x="255" y="74" width="495" height="18" rx="9" class="track"/><rect x="255" y="74" width="315.0" height="18" rx="9" class="bar"/><text x="802" y="88" text-anchor="end" class="value">14 · 16%</text>
+<text x="24" y="126" class="label">ML engineering &amp; MLOps</text><rect x="255" y="112" width="495" height="18" rx="9" class="track"/><rect x="255" y="112" width="225.0" height="18" rx="9" class="bar"/><text x="802" y="126" text-anchor="end" class="value">10 · 11%</text>
+<text x="24" y="164" class="label">Scientific ML &amp; deep learning</text><rect x="255" y="150" width="495" height="18" rx="9" class="track"/><rect x="255" y="150" width="157.5" height="18" rx="9" class="bar"/><text x="802" y="164" text-anchor="end" class="value">7 · 8%</text>
+<text x="24" y="202" class="label">Data engineering &amp; streaming</text><rect x="255" y="188" width="495" height="18" rx="9" class="track"/><rect x="255" y="188" width="157.5" height="18" rx="9" class="bar"/><text x="802" y="202" text-anchor="end" class="value">7 · 8%</text>
+<text x="24" y="240" class="label">Statistics &amp; applied DS</text><rect x="255" y="226" width="495" height="18" rx="9" class="track"/><rect x="255" y="226" width="292.5" height="18" rx="9" class="bar"/><text x="802" y="240" text-anchor="end" class="value">13 · 15%</text>
+<text x="24" y="278" class="label">Optimisation &amp; decisions</text><rect x="255" y="264" width="495" height="18" rx="9" class="track"/><rect x="255" y="264" width="67.5" height="18" rx="9" class="bar"/><text x="802" y="278" text-anchor="end" class="value">3 · 3%</text>
+<text x="24" y="316" class="label">Economics, finance &amp; policy</text><rect x="255" y="302" width="495" height="18" rx="9" class="track"/><rect x="255" y="302" width="495.0" height="18" rx="9" class="bar"/><text x="802" y="316" text-anchor="end" class="value">22 · 25%</text>
+<text x="24" y="354" class="label">Mathematics &amp; algorithms</text><rect x="255" y="340" width="495" height="18" rx="9" class="track"/><rect x="255" y="340" width="157.5" height="18" rx="9" class="bar"/><text x="802" y="354" text-anchor="end" class="value">7 · 8%</text>
+<text x="24" y="392" class="label">Developer tooling</text><rect x="255" y="378" width="495" height="18" rx="9" class="track"/><rect x="255" y="378" width="90.0" height="18" rx="9" class="bar"/><text x="802" y="392" text-anchor="end" class="value">4 · 5%</text>
+</svg>

--- a/scripts/generate_topic_statistics.py
+++ b/scripts/generate_topic_statistics.py
@@ -1,0 +1,110 @@
+"""Generate the GitHub profile topic-statistics SVG from PROJECTS.md.
+
+The script counts curated project entries under selected second-level headings and
+renders a dependency-free SVG suitable for embedding directly in Markdown.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECTS_PATH = ROOT / "PROJECTS.md"
+OUTPUT_PATH = ROOT / "assets" / "topic-statistics.svg"
+
+TOPIC_LABELS: dict[str, str] = {
+    "Production AI & LLM Systems": "AI & LLM systems",
+    "ML Engineering & MLOps": "ML engineering & MLOps",
+    "Deep Learning & Scientific Computing": "Scientific ML & deep learning",
+    "Data Engineering & Streaming": "Data engineering & streaming",
+    "Statistical & Applied Data Science": "Statistics & applied DS",
+    "Optimisation & Decision Systems": "Optimisation & decisions",
+    "Economics, Finance & Policy Research": "Economics, finance & policy",
+    "Mathematical Methods & Algorithms": "Mathematics & algorithms",
+    "Developer Tooling": "Developer tooling",
+}
+
+HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
+PROJECT_RE = re.compile(r"^-\s+")
+
+
+def count_topics(markdown: str) -> dict[str, int]:
+    """Count project bullets beneath the configured second-level headings."""
+    counts = {heading: 0 for heading in TOPIC_LABELS}
+    active_heading: str | None = None
+
+    for raw_line in markdown.splitlines():
+        heading_match = HEADING_RE.match(raw_line)
+        if heading_match:
+            heading = heading_match.group(1).strip()
+            active_heading = heading if heading in counts else None
+            continue
+
+        if active_heading is not None and PROJECT_RE.match(raw_line):
+            counts[active_heading] += 1
+
+    if not any(counts.values()):
+        raise ValueError("No project entries were found under configured topic headings.")
+
+    return counts
+
+
+def render_svg(counts: dict[str, int]) -> str:
+    """Render a responsive horizontal-bar SVG from topic counts."""
+    rows = [(TOPIC_LABELS[key], counts[key]) for key in TOPIC_LABELS]
+    total = sum(value for _, value in rows)
+    maximum = max(value for _, value in rows)
+
+    width = 820
+    left = 255
+    right = 70
+    top = 74
+    row_height = 38
+    bar_height = 18
+    chart_width = width - left - right
+    height = top + len(rows) * row_height + 48
+
+    elements: list[str] = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
+        '<title id="title">Project topics</title>',
+        f'<desc id="desc">Distribution of {total} curated project entries across technical and research topics.</desc>',
+        '<style>',
+        'text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#c9d1d9}',
+        '.muted{fill:#8b949e}.label{font-size:14px}.value{font-size:13px;font-weight:600}.title{font-size:20px;font-weight:700}.subtitle{font-size:13px}',
+        '.track{fill:#21262d}.bar{fill:#58a6ff}',
+        '@media (prefers-color-scheme: light){text{fill:#24292f}.muted{fill:#57606a}.track{fill:#d8dee4}.bar{fill:#0969da}}',
+        '</style>',
+        '<text x="24" y="30" class="title">Topics I work on</text>',
+        f'<text x="24" y="52" class="subtitle muted">{total} curated project entries · generated from PROJECTS.md</text>',
+    ]
+
+    for index, (label, value) in enumerate(rows):
+        y = top + index * row_height
+        bar_width = 0 if maximum == 0 else chart_width * value / maximum
+        percentage = 0 if total == 0 else 100 * value / total
+        escaped_label = html.escape(label)
+        elements.extend(
+            [
+                f'<text x="24" y="{y + 14}" class="label">{escaped_label}</text>',
+                f'<rect x="{left}" y="{y}" width="{chart_width}" height="{bar_height}" rx="9" class="track"/>',
+                f'<rect x="{left}" y="{y}" width="{bar_width:.1f}" height="{bar_height}" rx="9" class="bar"/>',
+                f'<text x="{width - 18}" y="{y + 14}" text-anchor="end" class="value">{value} · {percentage:.0f}%</text>',
+            ]
+        )
+
+    elements.append('</svg>')
+    return "\n".join(elements) + "\n"
+
+
+def main() -> None:
+    """Read the catalogue, compute counts, and write the SVG widget."""
+    markdown = PROJECTS_PATH.read_text(encoding="utf-8")
+    counts = count_topics(markdown)
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(render_svg(counts), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Turn the Statistics page into a quantitative view of the areas represented in the curated project catalogue.

### Changes
- add `assets/topic-statistics.svg`, a horizontal topic-distribution widget
- derive the topic counts from the second-level project sections in `PROJECTS.md`
- add `scripts/generate_topic_statistics.py` with typed, dependency-free SVG generation
- add a GitHub Actions workflow that regenerates and commits the widget whenever `PROJECTS.md` or the generator changes
- embed the widget at the top of `STATISTICS.md`
- keep the existing committers.top and GitHub trophy widgets below it
- include the Featured tab in the Statistics navigation for consistency

The current snapshot contains 87 curated project entries across nine topic families. The chart is generated from the catalogue rather than maintained by hand.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-updating topic statistics widget to the Statistics page showing the distribution of curated projects across nine topic families.

- Generates `assets/topic-statistics.svg` from the second-level topic sections in `PROJECTS.md` via a new typed, dependency-free Python script.
- Adds a GitHub Actions workflow that regenerates and commits the widget whenever `PROJECTS.md` or the generator changes.
- Embeds the widget at the top of `STATISTICS.md` and adds a Featured tab link to the Statistics navigation, keeping the existing committers.top and GitHub trophy widgets below.

<sup>Written for commit 925a2cd94378314bb18d5b45a33459638d892080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

