### PR TITLE
Replace vanity statistics and add PyPI tab

### DIFF
--- a/.github/workflows/portfolio-evidence.yml
+++ b/.github/workflows/portfolio-evidence.yml
@@ -1,0 +1,44 @@
+name: Portfolio evidence metrics
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "FEATURED.md"
+      - "scripts/generate_portfolio_metrics.py"
+      - ".github/workflows/portfolio-evidence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate evidence dashboard
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/generate_portfolio_metrics.py
+
+      - name: Commit refreshed dashboard
+        run: |
+          if git diff --quiet -- assets/portfolio-evidence.svg; then
+            echo "Portfolio evidence dashboard is already current."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/portfolio-evidence.svg
+          git commit -m "chore: refresh portfolio evidence metrics"
+          git push

--- a/.github/workflows/portfolio-evidence.yml
+++ b/.github/workflows/portfolio-evidence.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Commit refreshed dashboard
         run: |
-          if git diff --quiet -- assets/portfolio-evidence.svg; then
+          if [ -z "$(git status --porcelain -- assets/portfolio-evidence.svg)" ]; then
             echo "Portfolio evidence dashboard is already current."
             exit 0
           fi

--- a/PYPI.md
+++ b/PYPI.md
@@ -1,0 +1,110 @@
+<div align="center">
+  <a href="https://github.com/DiogoRibeiro7"><img src="https://img.shields.io/badge/Home-30363D?style=for-the-badge" alt="Home" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md"><img src="https://img.shields.io/badge/Featured-30363D?style=for-the-badge" alt="Featured" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md"><img src="https://img.shields.io/badge/Projects-30363D?style=for-the-badge" alt="Projects" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
+  <img src="https://img.shields.io/badge/PyPI-1F6FEB?style=for-the-badge&logo=pypi&logoColor=white" alt="PyPI (current page)" />
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md"><img src="https://img.shields.io/badge/Statistics-30363D?style=for-the-badge" alt="Statistics" /></a>
+</div>
+
+---
+
+# PyPI Packages
+
+Python packages I maintain and publish on the Python Package Index. The version badges below are read directly from PyPI, so this page does not need a manual version update after each release.
+
+## Statistical & Research Software
+
+### [`gen_surv`](https://pypi.org/project/gen-surv/)
+
+[![PyPI](https://img.shields.io/pypi/v/gen_surv?label=PyPI)](https://pypi.org/project/gen-surv/)
+[![Python](https://img.shields.io/pypi/pyversions/gen_surv)](https://pypi.org/project/gen-surv/)
+
+Survival-data simulation with known latent truth for estimator validation, covering proportional hazards, accelerated failure-time, competing-risk, cure, recurrent-event and multistate models.
+
+```bash
+pip install gen-surv
+```
+
+**Source:** [DiogoRibeiro7/genSurvPy](https://github.com/DiogoRibeiro7/genSurvPy)
+
+### [`setqca`](https://pypi.org/project/setqca/)
+
+[![PyPI](https://img.shields.io/pypi/v/setqca?label=PyPI)](https://pypi.org/project/setqca/)
+[![Python](https://img.shields.io/pypi/pyversions/setqca)](https://pypi.org/project/setqca/)
+
+Native typed Python implementation of crisp-set and fuzzy-set Qualitative Comparative Analysis with exact Boolean minimisation and validation against the reference R implementation.
+
+```bash
+pip install setqca
+```
+
+**Source:** [DiogoRibeiro7/setqca-python](https://github.com/DiogoRibeiro7/setqca-python)
+
+---
+
+## Scientific Machine Learning
+
+### [`pinnlab`](https://pypi.org/project/pinnlab/)
+
+[![PyPI](https://img.shields.io/pypi/v/pinnlab?label=PyPI)](https://pypi.org/project/pinnlab/)
+[![Python](https://img.shields.io/pypi/pyversions/pinnlab)](https://pypi.org/project/pinnlab/)
+
+Physics-Informed Neural Network toolkit for PDEs, inverse problems, scientific-machine-learning experiments, diagnostics, and reproducible benchmarking.
+
+```bash
+pip install pinnlab
+```
+
+**Source:** [DiogoRibeiro7/pinn](https://github.com/DiogoRibeiro7/pinn)
+
+### [`pinn-rk`](https://pypi.org/project/pinn-rk/)
+
+[![PyPI](https://img.shields.io/pypi/v/pinn-rk?label=PyPI)](https://pypi.org/project/pinn-rk/)
+[![Python](https://img.shields.io/pypi/pyversions/pinn-rk)](https://pypi.org/project/pinn-rk/)
+
+Runge-Kutta Physics-Informed Neural Networks for time-discrete PDE learning with implicit RK schemes.
+
+```bash
+pip install pinn-rk
+```
+
+**Source:** [DiogoRibeiro7/pinn-rk](https://github.com/DiogoRibeiro7/pinn-rk)
+
+---
+
+## Time Series & Sensing
+
+### [`tscv-vision`](https://pypi.org/project/tscv-vision/)
+
+[![PyPI](https://img.shields.io/pypi/v/tscv-vision?label=PyPI)](https://pypi.org/project/tscv-vision/)
+[![Python](https://img.shields.io/pypi/pyversions/tscv-vision)](https://pypi.org/project/tscv-vision/)
+
+Computer-vision-inspired feature engineering and representation tools for one-dimensional time series, with research, analytics and deployment-oriented extensions.
+
+```bash
+pip install tscv-vision
+```
+
+**Source:** [DiogoRibeiro7/tscv-vision](https://github.com/DiogoRibeiro7/tscv-vision)
+
+### [`wifi-activity-recognition`](https://pypi.org/project/wifi-activity-recognition/)
+
+[![PyPI](https://img.shields.io/pypi/v/wifi-activity-recognition?label=PyPI)](https://pypi.org/project/wifi-activity-recognition/)
+[![Python](https://img.shields.io/pypi/pyversions/wifi-activity-recognition)](https://pypi.org/project/wifi-activity-recognition/)
+
+CSI-based human-activity recognition with hardware abstraction, signal preprocessing, model training/evaluation, streaming workflows, and research utilities for adaptation and federated learning.
+
+```bash
+pip install wifi-activity-recognition
+```
+
+**Source:** [DiogoRibeiro7/wifi-csi-activity-recognition](https://github.com/DiogoRibeiro7/wifi-csi-activity-recognition)
+
+---
+
+## Verification
+
+These packages were included only where the PyPI project page identifies **DiogoRibeiro7 / Diogo Ribeiro** as maintainer or author and links the package to the corresponding source repository. The PyPI user-profile project count is currently stale, so this page uses the individual package records as the source of truth.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Statistical modelling, production AI, decision systems, and reproducible researc
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PYPI.md"><img src="https://img.shields.io/badge/PyPI-30363D?style=for-the-badge&logo=pypi&logoColor=white" alt="PyPI" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md"><img src="https://img.shields.io/badge/Statistics-30363D?style=for-the-badge" alt="Statistics" /></a>
 </div>
 
@@ -69,7 +70,8 @@ The common thread is simple: start from the problem and the evidence, use the le
 | :-- | :-- |
 | **[Featured →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md)**<br>Twelve flagship projects, grouped by what a reviewer is looking for. | **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>The broader catalogue across production, research, modelling, optimisation, and data engineering. |
 | **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The modelling toolbox, technical stack, and methods I use by problem type. | **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current programmes, research themes, reproducibility standards, and collaboration interests. |
-| **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. | **[Statistics →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md)**<br>GitHub activity and profile widgets kept separate from the technical portfolio. |
+| **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. | **[PyPI →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PYPI.md)**<br>Published Python packages with live version badges, install commands, and source links. |
+| **[Statistics →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md)**<br>Portfolio evidence, impact metrics, and topic distribution. |  |
 
 ---
 

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -12,19 +12,62 @@
 
 # Statistics
 
-A quantitative view of the areas represented in the curated project catalogue, followed by GitHub activity/profile widgets.
+Numbers that say something about the work itself: delivery impact, empirical depth, reproducibility, and the structure of the portfolio. Popularity metrics are deliberately secondary.
+
+## Delivered Impact
+
+These are outcomes from professional delivery rather than repository activity.
+
+| Metric | Result |
+| :-- | --: |
+| Reporting cost reduction | **80%** |
+| Analytics processing-time reduction | **30%** |
+| Inventory-value reduction through forecasting and operational optimisation | **€500K** |
+
+---
+
+## Flagship Evidence
+
+The denominator here is the **12 repositories in [`FEATURED.md`](FEATURED.md)**, not the entire GitHub account. Mechanical metrics are audited from repository structure; semantic classifications are explicit in the generator so they can be reviewed rather than guessed.
+
+<p align="center">
+  <img src="assets/portfolio-evidence.svg" alt="Evidence dashboard for the twelve flagship repositories, covering CI, tests, documentation, citation metadata, reproducibility assets, empirical work, and research software" width="100%" />
+</p>
+
+The evidence dashboard is regenerated from the flagship list. Its definitions live in [`scripts/generate_portfolio_metrics.py`](scripts/generate_portfolio_metrics.py). In particular, **real-data / empirical** and **research-software / methods** classifications are maintained explicitly because neither can be inferred reliably from filenames.
+
+### Portfolio structure
+
+| Measure | Current scope |
+| :-- | --: |
+| Flagship repositories | **12** |
+| Curated catalogue entries | **87** |
+| Major topic families | **9** |
+| Flagships explicitly classified as real-data / empirical | **6 / 12** |
+| Flagships explicitly classified as research software / statistical methods | **4 / 12** |
+
+---
 
 ## Topics I Work On
+
+This is a composition metric, not a quality metric. It shows where the curated project catalogue is concentrated.
 
 <p align="center">
   <img src="assets/topic-statistics.svg" alt="Bar chart showing the distribution of curated projects across the topics Diogo works on" width="100%" />
 </p>
 
-The chart is generated from the second-level topic sections in [`PROJECTS.md`](PROJECTS.md). Each listed project contributes one entry to its section, including explicitly marked private projects. The SVG is regenerated automatically whenever the project catalogue or generator changes.
+The topic chart is generated from the second-level sections in [`PROJECTS.md`](PROJECTS.md). Each listed project contributes one entry to its section, including explicitly marked private projects.
 
 ---
 
-## GitHub Activity
+## What I Do Not Use as a Quality Metric
+
+Stars, follower counts, raw commit totals, contribution streaks, and profile trophies can be interesting activity signals, but they do not establish modelling quality, scientific validity, production reliability, or business impact. They are kept below for completeness rather than used as evidence of technical quality.
+
+<details>
+<summary><strong>GitHub activity widgets</strong></summary>
+
+<br>
 
 <div align="center">
   <a href="https://user-badge.committers.top/portugal_private/DiogoRibeiro7">
@@ -39,3 +82,5 @@ The chart is generated from the second-level topic sections in [`PROJECTS.md`](P
     <img src="https://github-profile-trophy-unserori.vercel.app/?username=DiogoRibeiro7&column=3&no-frame=true&theme=algolia" alt="GitHub profile trophies" />
   </a>
 </div>
+
+</details>

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -5,6 +5,7 @@
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
+  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PYPI.md"><img src="https://img.shields.io/badge/PyPI-30363D?style=for-the-badge&logo=pypi&logoColor=white" alt="PyPI" /></a>
   <img src="https://img.shields.io/badge/Statistics-1F6FEB?style=for-the-badge" alt="Statistics (current page)" />
 </div>
 

--- a/scripts/generate_portfolio_metrics.py
+++ b/scripts/generate_portfolio_metrics.py
@@ -1,0 +1,234 @@
+"""Generate evidence-based portfolio metrics for the profile statistics page.
+
+The generator audits the repositories listed in FEATURED.md using the GitHub
+Contents API. Mechanical metrics are discovered from repository structure.
+Semantic metrics that cannot be inferred safely from filenames are maintained
+in an explicit, reviewable manifest below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+from xml.sax.saxutils import escape
+
+OWNER: Final[str] = "DiogoRibeiro7"
+FEATURED_PATH: Final[Path] = Path("FEATURED.md")
+OUTPUT_PATH: Final[Path] = Path("assets/portfolio-evidence.svg")
+API_ROOT: Final[str] = "https://api.github.com"
+
+# These classifications require scientific judgement and are therefore
+# explicit rather than guessed from filenames.
+REAL_DATA_OR_EMPIRICAL: Final[frozenset[str]] = frozenset(
+    {
+        "qwen-text2sql-lab",
+        "clinic-forecasting-platform",
+        "transaction-risk-lakehouse",
+        "oisst-fourier-neural-operator",
+        "portugal-public-pension-financing",
+        "short-rate-anomaly-regimes",
+    }
+)
+
+RESEARCH_SOFTWARE_OR_METHOD_PACKAGE: Final[frozenset[str]] = frozenset(
+    {
+        "genSurvPy",
+        "setqca-python",
+        "behavioral-sensing-research",
+        "bmssp",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RepoEvidence:
+    """Mechanical quality signals found in one flagship repository."""
+
+    name: str
+    has_ci: bool
+    has_tests: bool
+    has_docs: bool
+    has_citation: bool
+    has_reproducibility_assets: bool
+
+
+def _headers() -> dict[str, str]:
+    """Return GitHub API request headers, using the Actions token when present."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "diogoribeiro7-profile-metrics",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _get_json(url: str) -> object:
+    """Fetch and decode a GitHub API JSON response."""
+    request = urllib.request.Request(url, headers=_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []
+        raise RuntimeError(f"GitHub API request failed: {url} ({exc.code})") from exc
+
+
+def _contents(repo: str, path: str = "") -> list[dict[str, object]]:
+    """Return directory entries from one repository path."""
+    suffix = f"/{path}" if path else ""
+    payload = _get_json(f"{API_ROOT}/repos/{OWNER}/{repo}/contents{suffix}")
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def _names(entries: list[dict[str, object]]) -> set[str]:
+    """Return entry names with runtime type validation."""
+    result: set[str] = set()
+    for item in entries:
+        name = item.get("name")
+        if isinstance(name, str):
+            result.add(name)
+    return result
+
+
+def _featured_repos() -> list[str]:
+    """Parse public GitHub repository names from the flagship table."""
+    text = FEATURED_PATH.read_text(encoding="utf-8")
+    matches = re.findall(r"https://github\.com/DiogoRibeiro7/([^/)#]+)", text)
+    excluded = {"diogoribeiro7"}
+    repos = list(dict.fromkeys(repo for repo in matches if repo not in excluded))
+    if len(repos) != 12:
+        raise ValueError(f"Expected 12 flagship repositories, found {len(repos)}: {repos}")
+    return repos
+
+
+def _audit_repo(repo: str) -> RepoEvidence:
+    """Audit mechanically verifiable repository-level evidence."""
+    root = _names(_contents(repo))
+    github = _names(_contents(repo, ".github")) if ".github" in root else set()
+    workflows = _contents(repo, ".github/workflows") if "workflows" in github else []
+
+    docs_markers = {"docs", "mkdocs.yml", "mkdocs.yaml", "docs.yml", "docs.yaml"}
+    test_markers = {"tests", "test", "pytest.ini", "tox.ini"}
+    citation_markers = {"CITATION.cff", ".zenodo.json"}
+    reproducibility_markers = {
+        "experiments",
+        "artifacts",
+        "results",
+        "reports",
+        "notebooks",
+        "data",
+        "data_sources",
+        "config",
+        "configs",
+    }
+
+    return RepoEvidence(
+        name=repo,
+        has_ci=bool(workflows),
+        has_tests=bool(root & test_markers),
+        has_docs=bool(root & docs_markers),
+        has_citation=bool(root & citation_markers),
+        has_reproducibility_assets=bool(root & reproducibility_markers),
+    )
+
+
+def _metric(label: str, count: int, total: int, note: str) -> tuple[str, str, str]:
+    """Format one metric tuple for rendering."""
+    pct = 100.0 * count / total
+    return label, f"{count}/{total} · {pct:.0f}%", note
+
+
+def _render_svg(metrics: list[tuple[str, str, str]], total: int) -> str:
+    """Render a compact dark/light-compatible SVG metrics dashboard."""
+    width = 900
+    card_w = 420
+    card_h = 104
+    gap = 20
+    rows = (len(metrics) + 1) // 2
+    height = 90 + rows * (card_h + gap) + 42
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
+        '<title id="title">Flagship portfolio evidence metrics</title>',
+        f'<desc id="desc">Evidence metrics computed across {total} flagship repositories.</desc>',
+        '<style>',
+        'text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#c9d1d9}',
+        '.title{font-size:24px;font-weight:700}.sub{font-size:13px;fill:#8b949e}',
+        '.card{fill:#161b22;stroke:#30363d;stroke-width:1}.label{font-size:14px;font-weight:600}',
+        '.value{font-size:24px;font-weight:700;fill:#58a6ff}.note{font-size:11px;fill:#8b949e}',
+        '</style>',
+        '<rect width="100%" height="100%" rx="12" fill="#0d1117"/>',
+        '<text x="24" y="34" class="title">Flagship portfolio evidence</text>',
+        f'<text x="24" y="58" class="sub">Audited across {total} featured repositories · structural signals, not popularity metrics</text>',
+    ]
+
+    for index, (label, value, note) in enumerate(metrics):
+        col = index % 2
+        row = index // 2
+        x = 24 + col * (card_w + gap)
+        y = 78 + row * (card_h + gap)
+        parts.extend(
+            [
+                f'<rect x="{x}" y="{y}" width="{card_w}" height="{card_h}" rx="10" class="card"/>',
+                f'<text x="{x + 18}" y="{y + 27}" class="label">{escape(label)}</text>',
+                f'<text x="{x + 18}" y="{y + 59}" class="value">{escape(value)}</text>',
+                f'<text x="{x + 18}" y="{y + 82}" class="note">{escape(note)}</text>',
+            ]
+        )
+
+    parts.append(
+        f'<text x="24" y="{height - 18}" class="sub">Generated from FEATURED.md + GitHub repository structure. Semantic classifications are explicit in scripts/generate_portfolio_metrics.py.</text>'
+    )
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    """Audit the flagship set and write the portfolio evidence SVG."""
+    repos = _featured_repos()
+    evidence = [_audit_repo(repo) for repo in repos]
+    total = len(evidence)
+
+    metrics = [
+        _metric("CI-backed", sum(item.has_ci for item in evidence), total, "GitHub Actions workflow present"),
+        _metric("Automated tests", sum(item.has_tests for item in evidence), total, "tests/test/pytest/tox marker present"),
+        _metric("Dedicated documentation", sum(item.has_docs for item in evidence), total, "docs directory or docs config present"),
+        _metric("Citable / archived", sum(item.has_citation for item in evidence), total, "CITATION.cff or Zenodo metadata present"),
+        _metric(
+            "Reproducibility assets",
+            sum(item.has_reproducibility_assets for item in evidence),
+            total,
+            "experiments/results/data/config-style artifacts present",
+        ),
+        _metric(
+            "Real-data / empirical",
+            len(REAL_DATA_OR_EMPIRICAL & set(repos)),
+            total,
+            "explicit curated classification; never inferred from filenames",
+        ),
+        _metric(
+            "Research software / methods",
+            len(RESEARCH_SOFTWARE_OR_METHOD_PACKAGE & set(repos)),
+            total,
+            "explicit flagship classification",
+        ),
+    ]
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(_render_svg(metrics, total), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Refocus the Statistics page on metrics that say something about technical and research quality rather than GitHub popularity, and add a dedicated PyPI page for published Python packages.

### Statistics changes
- lead with delivered outcomes: 80% reporting-cost reduction, 30% analytics processing-time reduction, and €500K inventory-value reduction
- add an evidence dashboard over the 12 flagship repositories
- audit mechanical signals such as CI, automated tests, dedicated documentation, citation/Zenodo metadata, and reproducibility artifacts
- keep real-data/empirical and research-software/method classifications explicit and reviewable instead of guessing them from repository names
- retain portfolio composition metrics: 87 curated entries, 12 flagships, and 9 topic families
- keep the topic-distribution widget as a secondary composition view rather than presenting it as quality
- move committers.top and GitHub trophies into a collapsed activity section and state explicitly that stars, commits, streaks, followers, and trophies are not quality metrics
- add a self-updating GitHub Actions workflow for the flagship evidence SVG

### PyPI changes
- add `PYPI.md` as a first-class profile tab
- list only packages verified on their individual PyPI project pages
- include live PyPI version and Python-version badges, install commands, concise descriptions, and source-repository links
- currently include `gen_surv`, `setqca`, `pinnlab`, `pinn-rk`, `tscv-vision`, and `wifi-activity-recognition`
- add the PyPI tab to the main profile and Statistics navigation

The result is intended to answer both: what evidence exists that the work is reproducible, tested, documented, empirical, citable, and useful; and which of that work is available as installable Python software?