### PR TITLE
Fix duplicated homepage navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-<div align="center">
-  <img src="https://img.shields.io/badge/Home-1F6FEB?style=for-the-badge" alt="Home (current page)" />
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md"><img src="https://img.shields.io/badge/Featured-30363D?style=for-the-badge" alt="Featured" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md"><img src="https://img.shields.io/badge/Projects-30363D?style=for-the-badge" alt="Projects" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md"><img src="https://img.shields.io/badge/Methods-30363D?style=for-the-badge" alt="Methods" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md"><img src="https://img.shields.io/badge/Research-30363D?style=for-the-badge" alt="Research" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/OUTPUTS.md"><img src="https://img.shields.io/badge/Outputs-30363D?style=for-the-badge" alt="Outputs" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/CASE_STUDIES.md"><img src="https://img.shields.io/badge/Case%20Studies-30363D?style=for-the-badge" alt="Case Studies" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PYPI.md"><img src="https://img.shields.io/badge/PyPI-30363D?style=for-the-badge&logo=pypi&logoColor=white" alt="PyPI" /></a>
-  <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md"><img src="https://img.shields.io/badge/Statistics-30363D?style=for-the-badge" alt="Statistics" /></a>
-</div>
-
----
-
 # Diogo Ribeiro
 
 **Lead Data Scientist · Mathematician · AI/ML Engineer · Researcher & Lecturer**  

--- a/scripts/profile_maintenance.py
+++ b/scripts/profile_maintenance.py
@@ -21,6 +21,10 @@ PAGES = [
 ]
 MATURITY_START = "<!-- maturity:start -->"
 MATURITY_END = "<!-- maturity:end -->"
+NAV_PATTERN = re.compile(
+    r'<div align="center">\n(?=(?:(?!</div>)[\s\S])*img\.shields\.io/badge/Home-).*?</div>\n*',
+    re.DOTALL,
+)
 
 
 def load_manifest() -> dict:
@@ -48,10 +52,16 @@ def nav_html(current: str, manifest: dict) -> str:
 
 def replace_nav(text: str, current: str, manifest: dict) -> str:
     replacement = nav_html(current, manifest)
-    pattern = re.compile(r'^<div align="center">\n.*?</div>', re.DOTALL)
-    if pattern.search(text):
-        return pattern.sub(replacement, text, count=1)
-    return replacement + "\n\n---\n\n" + text.lstrip()
+    cleaned = NAV_PATTERN.sub("", text)
+
+    if current == "README.md":
+        anchor = "Statistical modelling, production AI, decision systems, and reproducible research · Python-first"
+        if anchor not in cleaned:
+            raise ValueError("README navigation anchor not found")
+        before, after = cleaned.split(anchor, 1)
+        return before + anchor + "\n\n" + replacement + after.lstrip("\n")
+
+    return replacement + "\n\n---\n\n" + cleaned.lstrip("\n- ")
 
 
 def project_url(repo: str, path: str | None = None, ref: str = "main") -> str:
@@ -260,8 +270,19 @@ def check(manifest: dict) -> list[str]:
         if not fp.exists():
             continue
         text = fp.read_text(encoding="utf-8")
-        if not text.startswith(canonical_nav[path]):
+        nav_blocks = NAV_PATTERN.findall(text)
+        if len(nav_blocks) != 1:
+            errors.append(f"expected exactly one navigation block in {path}, found {len(nav_blocks)}")
+            continue
+        if canonical_nav[path] not in text:
             errors.append(f"navigation is stale: {path}")
+        if path == "README.md":
+            title_pos = text.find("# Diogo Ribeiro")
+            nav_pos = text.find(canonical_nav[path])
+            if title_pos < 0 or nav_pos < title_pos:
+                errors.append("README navigation must appear below the profile title")
+        elif not text.startswith(canonical_nav[path]):
+            errors.append(f"navigation must be first on secondary page: {path}")
     projects_text = (ROOT / "PROJECTS.md").read_text(encoding="utf-8")
     if MATURITY_START not in projects_text or MATURITY_END not in projects_text:
         errors.append("PROJECTS.md maturity legend is missing")


### PR DESCRIPTION
## Summary

Fix the homepage regression introduced by the manifest-driven navigation generator.

### Changes
- remove the duplicated navigation block currently rendered above the profile title
- keep exactly one canonical navigation row under the profile subtitle on `README.md`
- make the generator strip all existing navigation blocks before inserting the canonical one
- keep secondary pages with exactly one navigation block at the top
- strengthen the integrity check to require exactly one navigation block per page and to enforce the homepage placement below the profile title

The bug happened because the generator assumed every page should start with navigation, while the homepage historically places navigation below the name/title block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated homepage navigation caused by the manifest-driven generator, which assumed every page starts with navigation while the homepage places it below the profile title.

- Removes the duplicate navigation block above the profile title on `README.md`.
- The generator now strips existing navigation blocks before inserting the canonical one.
- Homepage navigation is inserted below the profile subtitle; secondary pages keep navigation at the top.
- The integrity check now requires exactly one navigation block per page and enforces the homepage placement rule.

<sup>Written for commit 4adc6f25d222b3005533008ee718bb9312e02d81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

