### PR TITLE
Apply agreed UI review fixes

### DIFF
--- a/.github/workflows/profile-integrity.yml
+++ b/.github/workflows/profile-integrity.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Validate manifest schema and generated model
         run: |
           python scripts/profile_maintenance.py generate
+          python scripts/normalize_readme_layout.py
           python scripts/generate_portfolio_overview.py
           python scripts/generate_topic_statistics.py
           python scripts/profile_maintenance.py check
@@ -36,4 +37,4 @@ jobs:
         run: python scripts/check_external_inventory.py
 
       - name: Check Python syntax
-        run: python -m py_compile scripts/profile_maintenance.py scripts/check_external_inventory.py scripts/generate_portfolio_overview.py scripts/generate_topic_statistics.py scripts/generate_portfolio_metrics.py
+        run: python -m py_compile scripts/profile_maintenance.py scripts/normalize_readme_layout.py scripts/check_external_inventory.py scripts/generate_portfolio_overview.py scripts/generate_topic_statistics.py scripts/generate_portfolio_metrics.py

--- a/.github/workflows/profile-maintenance.yml
+++ b/.github/workflows/profile-maintenance.yml
@@ -12,6 +12,7 @@ on:
       - "TEACHING.md"
       - "STATISTICS.md"
       - "scripts/profile_maintenance.py"
+      - "scripts/normalize_readme_layout.py"
       - "scripts/generate_topic_statistics.py"
       - "scripts/generate_portfolio_metrics.py"
       - "scripts/generate_portfolio_overview.py"
@@ -41,6 +42,9 @@ jobs:
 
       - name: Regenerate manifest-backed pages and navigation
         run: python scripts/profile_maintenance.py generate
+
+      - name: Normalize README layout
+        run: python scripts/normalize_readme_layout.py
 
       - name: Regenerate portfolio-wide statistics
         run: python scripts/generate_portfolio_overview.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Statistical modelling, production AI, decision systems, and reproducible researc
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md"><img src="https://img.shields.io/badge/Teaching-30363D?style=for-the-badge" alt="Teaching" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PYPI.md"><img src="https://img.shields.io/badge/PyPI-30363D?style=for-the-badge&logo=pypi&logoColor=white" alt="PyPI" /></a>
   <a href="https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md"><img src="https://img.shields.io/badge/Statistics-30363D?style=for-the-badge" alt="Statistics" /></a>
-</div>I build data and AI systems where the difficult part starts after model fitting: defining the estimand, validating uncertainty, detecting distribution shift, choosing the operating policy, and keeping the result reproducible in production. My work moves between statistical modelling, machine learning, research software, production AI, optimisation, and applied quantitative research.
+</div>
+
+I build data and AI systems where the difficult part starts after model fitting: defining the estimand, validating uncertainty, detecting distribution shift, choosing the operating policy, and keeping the result reproducible in production. My work moves between statistical modelling, machine learning, research software, production AI, optimisation, and applied quantitative research.
 
 **Selected delivery outcomes:** 80% reduction in reporting costs · 30% reduction in analytics processing time · €500K reduction in inventory value through forecasting and operational optimisation.
 
@@ -69,7 +71,7 @@ The common thread is simple: start from the problem and the evidence, use the le
 |  |  |
 | :-- | :-- |
 | **[Featured →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/FEATURED.md)**<br>Twelve flagship projects with explicit maturity labels. | **[Projects →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PROJECTS.md)**<br>The broader catalogue across production, research, modelling, optimisation, and data engineering. |
-| **[Outputs →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/OUTPUTS.md)**<br>Citable research software, paper programmes, empirical studies, and archived releases. | **[Case Studies →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/CASE_STUDIES.md)**<br>Five end-to-end examples from problem and constraints to method and outcome. |
+| **[Outputs →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/OUTPUTS.md)**<br>Citable research software, paper programmes, empirical studies, and archived releases. | **[Case Studies →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/CASE_STUDIES.md)**<br>Thirteen end-to-end examples across eleven domains, from problem and constraints to method and outcome. |
 | **[Methods →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/METHODS.md)**<br>The modelling toolbox, technical stack, and methods I use by problem type. | **[Research →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/RESEARCH.md)**<br>Current programmes, research themes, reproducibility standards, and collaboration interests. |
 | **[Teaching →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/TEACHING.md)**<br>University teaching, seminars, workshops, and supporting material. | **[PyPI →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/PYPI.md)**<br>Published Python packages with live version badges, install commands, and source links. |
 | **[Statistics →](https://github.com/DiogoRibeiro7/diogoribeiro7/blob/main/STATISTICS.md)**<br>Portfolio evidence, impact metrics, and topic distribution. |  |

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -15,19 +15,9 @@
 
 # Statistics
 
-Quantitative evidence about the portfolio: scale, maturity, empirical depth, publication/output depth, reproducibility controls and delivered impact. Each section states its denominator so unlike quantities are not silently mixed.
+Quantitative evidence about the portfolio: scale, maturity, empirical depth, publication/output depth, reproducibility controls and delivered impact.
 
-## Delivered Impact
-
-Professional outcomes are shown separately from repository metrics because GitHub activity is not a proxy for delivery.
-
-| Delivered outcome | Result |
-| :-- | --: |
-| Reporting cost reduction | **80%** |
-| Analytics processing-time reduction | **30%** |
-| Inventory-value reduction through forecasting and operational optimisation | **€500K** |
-
----
+**At a glance:** **35 manifest-backed public projects · 32 substantial outputs · 13 case studies across 11 domains · 12 flagship repositories · 87 curated catalogue entries.** These are different populations used for different questions; the detailed definitions are documented below.
 
 ## Portfolio-Wide Evidence
 
@@ -61,6 +51,18 @@ The **32 outputs** currently break down into:
 | Decision and engineering artifacts | **10** |
 
 This is an artifact count, not a repository count: a repository can legitimately produce more than one inspectable output.
+
+---
+
+## Delivered Impact
+
+Professional outcomes are kept separate from repository metrics because GitHub activity is not a proxy for delivery.
+
+| Delivered outcome | Result |
+| :-- | --: |
+| Reporting cost reduction | **80%** |
+| Analytics processing-time reduction | **30%** |
+| Inventory-value reduction through forecasting and operational optimisation | **€500K** |
 
 ---
 

--- a/scripts/normalize_readme_layout.py
+++ b/scripts/normalize_readme_layout.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+README = Path("README.md")
+NAV_END = "</div>"
+INTRO = "I build data and AI systems"
+
+text = README.read_text(encoding="utf-8")
+needle = f"{NAV_END}{INTRO}"
+replacement = f"{NAV_END}\n\n{INTRO}"
+
+if needle in text:
+    text = text.replace(needle, replacement, 1)
+
+if f"{NAV_END}\n\n{INTRO}" not in text:
+    raise SystemExit("README navigation is not separated from the introduction by a blank line")
+
+README.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary

Apply the four UI changes accepted from the adversarial review.

### Statistics hierarchy
- move Delivered Impact below Portfolio-Wide Evidence so the Statistics tab opens with portfolio statistics rather than business outcomes
- add a compact denominator summary directly below the Statistics introduction: 35 manifest-backed public projects, 32 outputs, 13 case studies across 11 domains, 12 flagships, and 87 catalogue entries
- retain the detailed Definitions and Boundaries table later on the page as reference

### Homepage fixes
- restore a blank line between the generated navigation block and the homepage introduction
- update the stale Case Studies Explore copy from five examples to 13 cases across 11 domains

### Generation / integrity
- add `scripts/normalize_readme_layout.py` so the README spacing fix survives automated regeneration
- run the normalizer in both profile maintenance and pull-request integrity CI
- include the normalizer in Python syntax checking

This PR intentionally addresses only review items 9, 10, 11 and 12; the other UI-review recommendations are left unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the four agreed UI-review fixes: the Statistics tab hierarchy is reordered, and the README homepage spacing and case-study count are corrected.

**Statistics hierarchy**
- Moves Delivered Impact below Portfolio-Wide Evidence so the tab opens with portfolio statistics.
- Adds a compact at-a-glance denominator summary below the introduction, keeping the detailed definitions lower on the page.

**README layout**
- Restores the blank line between the navigation block and the introduction.
- Adds `scripts/normalize_readme_layout.py` so the spacing fix survives regeneration, and runs it in maintenance and integrity CI.
- Updates the stale Case Studies copy from five examples to 13 across 11 domains.

<sup>Written for commit b9bb749a388baf560e3147c2fd37d2eecc6e4f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

