### PR TITLE
Update faculty name after institutional rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The common thread is simple: start from the problem and the evidence, use the le
 
 ## Work With Me
 
-I teach mathematics and data subjects at **ESMAD (Instituto Politécnico do Porto)** and work across statistical modelling, production AI, forecasting, optimisation, research software, and reproducible applied research.
+I teach mathematics and data subjects at the **Faculty of Media Arts and Design, Technical University of Porto** and work across statistical modelling, production AI, forecasting, optimisation, research software, and reproducible applied research.
 
 For collaboration, research, or professional enquiries, a short note describing the problem, constraints, and expected outcome is the best starting point.
 

--- a/TEACHING.md
+++ b/TEACHING.md
@@ -17,19 +17,19 @@
 
 Teaching is a core part of how I contribute — translating mathematical and technical ideas into material teams and students can apply in practice.
 
-- [Courses @ESMAD](#courses-esmad-instituto-politécnico-do-porto)
+- [Courses @ Faculty of Media Arts and Design](#courses--faculty-of-media-arts-and-design-technical-university-of-porto)
 - [Seminars & Workshops](#seminars--workshops)
 
 ---
 
-## Courses @ESMAD (Instituto Politécnico do Porto)
+## Courses @ Faculty of Media Arts and Design, Technical University of Porto
 
 - **Introduction to Logic & Set Theory** — Logic (prop/FO), sets, induction, and differential & integral calculus, with an emphasis on rigorous reasoning and the transition from discrete foundations to continuous mathematics.
 - **Linear Algebra & Analytic Geometry** — Vector spaces and linear maps; matrices and determinants; eigenvalues, diagonalisation, orthogonality and least squares; SVD and PCA; numerical stability; applications to optimisation and data science. ([course repo](https://github.com/DiogoRibeiro7/linear-algebra-with-python))
 - **NoSQL & MongoDB** — Document-oriented modelling, indexing and aggregation, query patterns, and practical work with real datasets. ([labs](https://github.com/DiogoRibeiro7/nosql-databases-labs))
 - **NLP & LLM mini-workshops** — Prompt design, evaluation, lightweight retrieval, structured outputs, and report generation, with attention to reliability in production.
 
-Course material is developed in the open where possible, so students keep a working repository rather than a set of slides. The [linear-algebra-tutor](https://github.com/DiogoRibeiro7/linear-algebra-tutor) — a RAG-driven Socratic tutoring system — was built for ESMAD students alongside the linear algebra course.
+Course material is developed in the open where possible, so students keep a working repository rather than a set of slides. The [linear-algebra-tutor](https://github.com/DiogoRibeiro7/linear-algebra-tutor) — a RAG-driven Socratic tutoring system — was built for students at the Faculty of Media Arts and Design alongside the linear algebra course.
 
 ---
 


### PR DESCRIPTION
Update the current teaching affiliation from ESMAD / Instituto Politécnico do Porto to **Faculty of Media Arts and Design, Technical University of Porto**.

Changes:
- update the profile README current affiliation
- update the Teaching page heading, navigation anchor, and student reference
- retain the historical `PROJECTS.md` description that the linear algebra tutor was built for ESMAD students, since that describes the institution name at the time of the project

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the current faculty name from ESMAD / Instituto Politécnico do Porto to the Faculty of Media Arts and Design, Technical University of Porto in the profile README and teaching page. The historical `PROJECTS.md` description is intentionally left unchanged since it reflects the institution name when the project was built.

<sup>Written for commit ed3167e5e1a00b628040bdbc03bd64a4134d6064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

