### PR TITLE
Improve statistics page and move profile views

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Statistical modelling, production AI, decision systems, and reproducible researc
 
 I build data and AI systems where the difficult part starts after model fitting: defining the estimand, validating uncertainty, detecting distribution shift, choosing the operating policy, and keeping the result reproducible in production. My work moves between statistical modelling, machine learning, research software, production AI, optimisation, and applied quantitative research.
 
-<p align="center">
-  <img src="https://komarev.com/ghpvc/?username=DiogoRibeiro7&label=Profile%20views&color=30363D&style=for-the-badge" alt="Profile views" />
-</p>
-
 **Selected delivery outcomes:** 80% reduction in reporting costs · 30% reduction in analytics processing time · €500K reduction in inventory value through forecasting and operational optimisation.
 
 The common thread is simple: start from the problem and the evidence, use the least complicated model that answers it well, and make the resulting claim inspectable.

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -15,13 +15,28 @@
 
 # Statistics
 
-Quantitative evidence about the portfolio: scale, maturity, empirical depth, publication/output depth, reproducibility controls and delivered impact.
+Quantitative evidence about the portfolio: scale, empirical depth, publication/output depth, reproducibility controls, delivered impact and secondary GitHub activity signals.
 
-**At a glance:** **35 manifest-backed public projects · 32 substantial outputs · 13 case studies across 11 domains · 12 flagship repositories · 87 curated catalogue entries.** These are different populations used for different questions; the detailed definitions are documented below.
+## Portfolio Snapshot
+
+| Portfolio signal | Current value |
+| :-- | --: |
+| Manifest-backed public projects | **35** |
+| Substantial outputs | **32** |
+| Case studies | **13 across 11 domains** |
+| Published PyPI packages | **8** |
+| Real-data / empirical projects | **23 / 35 (66%)** |
+| Research software / methods | **11 / 35 (31%)** |
+| Curated flagship repositories | **12** |
+| Curated catalogue entries | **87** |
+
+These figures intentionally use different populations for different questions. The denominator rules are explicit below rather than blending repository counts, output counts and catalogue entries into one headline number.
+
+---
 
 ## Portfolio-Wide Evidence
 
-**Denominator:** the **35 public projects represented in the canonical [`data/portfolio.json`](data/portfolio.json) manifest**. This is broader than the 12-project Featured subset and narrower than every repository ever created on the account.
+**Primary denominator:** the **35 public projects represented in the canonical [`data/portfolio.json`](data/portfolio.json) manifest**. This is broader than the 12-project Featured subset and narrower than every repository ever created on the account.
 
 <p align="center">
   <img src="assets/portfolio-overview.svg" alt="Portfolio-wide evidence dashboard showing project count, outputs, case studies, empirical work, research software, PyPI packages and maturity mix" width="100%" />
@@ -116,12 +131,18 @@ Keeping those populations separate avoids a common portfolio-statistics mistake:
 
 ---
 
-## Activity Metrics, Deliberately Secondary
+## GitHub Activity and Reach
 
-Stars, follower counts, raw commit totals, contribution streaks and profile trophies are activity/popularity signals. They do not establish modelling quality, scientific validity, production reliability, reproducibility or business impact.
+Activity and popularity are useful context, but they are deliberately separated from the evidence above. Profile views, contribution badges and trophies do not establish modelling quality, scientific validity, production reliability, reproducibility or business impact.
+
+<div align="center">
+  <img src="https://komarev.com/ghpvc/?username=DiogoRibeiro7&label=Profile%20views&color=30363D&style=for-the-badge" alt="Profile views" />
+</div>
+
+<br>
 
 <details>
-<summary><strong>GitHub activity widgets</strong></summary>
+<summary><strong>Additional GitHub activity widgets</strong></summary>
 
 <br>
 


### PR DESCRIPTION
## Summary

Improve the Statistics tab as the single quantitative overview for the profile while keeping the existing widgets intact.

### Changes
- add a clearer `Portfolio Snapshot` table at the top for fast scanning
- preserve the existing portfolio overview, engineering-control dashboard, topic chart, committers badge, and trophy widget
- move the profile view counter from the README into `STATISTICS.md`
- group the counter and the existing GitHub widgets under `GitHub Activity and Reach`
- keep popularity/activity signals explicitly secondary to portfolio evidence, reproducibility controls, and delivered outcomes
- remove the counter from the homepage so the README stays focused on positioning and selected work

No portfolio counts or denominators are changed by this PR; this is a presentation and information-hierarchy improvement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Statistics page as the single quantitative overview for the profile by adding a Portfolio Snapshot table at the top for fast scanning. No portfolio counts or denominators change; the existing portfolio overview, engineering-control dashboard, topic chart, committers badge, and trophy widget remain intact.

Moves the profile view counter from the README to the Statistics page so the homepage stays focused on positioning and selected work. Groups the counter with the existing GitHub widgets under GitHub Activity and Reach, keeping popularity signals explicitly secondary to portfolio evidence, reproducibility controls, and delivered outcomes.

<sup>Written for commit 6694ffa00623531955579cdb96c8c0bc62d65539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

