### PR TITLE
Keep Statistics tables synchronized with portfolio data

### DIFF
--- a/.github/workflows/profile-integrity.yml
+++ b/.github/workflows/profile-integrity.yml
@@ -31,10 +31,12 @@ jobs:
           python scripts/normalize_readme_layout.py
           python scripts/generate_portfolio_overview.py
           python scripts/generate_topic_statistics.py
+          python scripts/sync_statistics.py generate
           python scripts/profile_maintenance.py check
+          python scripts/sync_statistics.py check
 
       - name: Check public GitHub and PyPI inventory
         run: python scripts/check_external_inventory.py
 
       - name: Check Python syntax
-        run: python -m py_compile scripts/profile_maintenance.py scripts/normalize_readme_layout.py scripts/check_external_inventory.py scripts/generate_portfolio_overview.py scripts/generate_topic_statistics.py scripts/generate_portfolio_metrics.py
+        run: python -m py_compile scripts/profile_maintenance.py scripts/normalize_readme_layout.py scripts/check_external_inventory.py scripts/generate_portfolio_overview.py scripts/generate_topic_statistics.py scripts/generate_portfolio_metrics.py scripts/sync_statistics.py

--- a/.github/workflows/profile-maintenance.yml
+++ b/.github/workflows/profile-maintenance.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/generate_topic_statistics.py"
       - "scripts/generate_portfolio_metrics.py"
       - "scripts/generate_portfolio_overview.py"
+      - "scripts/sync_statistics.py"
       - ".github/workflows/profile-maintenance.yml"
   workflow_dispatch:
 
@@ -52,13 +53,18 @@ jobs:
       - name: Regenerate topic statistics
         run: python scripts/generate_topic_statistics.py
 
+      - name: Synchronise Statistics tables
+        run: python scripts/sync_statistics.py generate
+
       - name: Regenerate flagship engineering controls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/generate_portfolio_metrics.py
 
       - name: Validate generated state
-        run: python scripts/profile_maintenance.py check
+        run: |
+          python scripts/profile_maintenance.py check
+          python scripts/sync_statistics.py check
 
       - name: Commit refreshed profile artifacts
         run: |

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -19,6 +19,7 @@ Quantitative evidence about the portfolio: scale, empirical depth, publication/o
 
 ## Portfolio Snapshot
 
+<!-- statistics:snapshot:start -->
 | Portfolio signal | Current value |
 | :-- | --: |
 | Manifest-backed public projects | **35** |
@@ -29,6 +30,7 @@ Quantitative evidence about the portfolio: scale, empirical depth, publication/o
 | Research software / methods | **11 / 35 (31%)** |
 | Curated flagship repositories | **12** |
 | Curated catalogue entries | **87** |
+<!-- statistics:snapshot:end -->
 
 These figures intentionally use different populations for different questions. The denominator rules are explicit below rather than blending repository counts, output counts and catalogue entries into one headline number.
 
@@ -44,6 +46,7 @@ These figures intentionally use different populations for different questions. T
 
 ### Research and output depth
 
+<!-- statistics:depth:start -->
 | Measure | Current scope | What it means |
 | :-- | --: | :-- |
 | Manifest-backed public projects | **35** | Projects with explicit category, maturity and evidence metadata |
@@ -53,17 +56,20 @@ These figures intentionally use different populations for different questions. T
 | Research software / methods | **11 / 35 (31%)** | Explicitly classified libraries, methods and research tooling |
 | Case studies | **13 across 11 domains** | End-to-end problem → constraints → method → outcome narratives |
 | Curated flagship projects | **12** | Reviewer-oriented subset; deliberately not used as the portfolio denominator |
+<!-- statistics:depth:end -->
 
 ### Output composition
 
 The **32 outputs** currently break down into:
 
+<!-- statistics:outputs:start -->
 | Output class | Count |
 | :-- | --: |
 | Published research software | **8** |
 | Research and paper programmes | **5** |
 | Empirical and replication studies | **9** |
 | Decision and engineering artifacts | **10** |
+<!-- statistics:outputs:end -->
 
 This is an artifact count, not a repository count: a repository can legitimately produce more than one inspectable output.
 
@@ -119,6 +125,7 @@ Topic counts are therefore a **composition metric**, not a quality score and not
 
 The page intentionally uses different denominators for different questions:
 
+<!-- statistics:boundaries:start -->
 | Question | Denominator |
 | :-- | :-- |
 | What does the serious public portfolio contain? | **35 manifest-backed public projects** |
@@ -126,6 +133,7 @@ The page intentionally uses different denominators for different questions:
 | What can a reviewer inspect end-to-end? | **13 case studies across 11 domains** |
 | How strong are repository controls on the curated front page? | **12 flagship repositories** |
 | Where is the broad catalogue concentrated? | **87 PROJECTS.md entries** |
+<!-- statistics:boundaries:end -->
 
 Keeping those populations separate avoids a common portfolio-statistics mistake: presenting one convenient subset as if it described everything.
 

--- a/scripts/sync_statistics.py
+++ b/scripts/sync_statistics.py
@@ -1,0 +1,196 @@
+"""Synchronise human-readable statistics tables with canonical portfolio data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from generate_topic_statistics import count_topics
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "data" / "portfolio.json"
+PROJECTS_PATH = ROOT / "PROJECTS.md"
+STATISTICS_PATH = ROOT / "STATISTICS.md"
+
+SNAPSHOT_START = "<!-- statistics:snapshot:start -->"
+SNAPSHOT_END = "<!-- statistics:snapshot:end -->"
+DEPTH_START = "<!-- statistics:depth:start -->"
+DEPTH_END = "<!-- statistics:depth:end -->"
+OUTPUTS_START = "<!-- statistics:outputs:start -->"
+OUTPUTS_END = "<!-- statistics:outputs:end -->"
+BOUNDARIES_START = "<!-- statistics:boundaries:start -->"
+BOUNDARIES_END = "<!-- statistics:boundaries:end -->"
+
+
+def load_manifest() -> dict[str, Any]:
+    """Load and minimally validate the canonical portfolio manifest."""
+    payload: object = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError("Portfolio manifest must be a JSON object.")
+    for key in ("projects", "outputs", "case_studies"):
+        if key not in payload or not isinstance(payload[key], list):
+            raise TypeError(f"Manifest field {key!r} must be a list.")
+    return payload
+
+
+def catalogue_total() -> int:
+    """Count curated catalogue entries using the same parser as the topic widget."""
+    markdown = PROJECTS_PATH.read_text(encoding="utf-8")
+    counts = count_topics(markdown)
+    return sum(counts.values())
+
+
+def metrics(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Derive all Statistics-page counts from canonical sources."""
+    projects = manifest["projects"]
+    outputs = manifest["outputs"]
+    cases = manifest["case_studies"]
+
+    total = len(projects)
+    if total == 0:
+        raise ValueError("Portfolio manifest contains no projects.")
+
+    real_data = sum(bool(project.get("real_data")) for project in projects)
+    research_software = sum(bool(project.get("research_software")) for project in projects)
+    pypi = sum(bool(project.get("pypi")) for project in projects)
+    featured = sum(bool(project.get("featured")) for project in projects)
+    domains = len({case["domain"] for case in cases})
+    output_types = Counter(str(item["type"]) for item in outputs)
+
+    return {
+        "projects": total,
+        "outputs": len(outputs),
+        "cases": len(cases),
+        "domains": domains,
+        "pypi": pypi,
+        "real_data": real_data,
+        "research_software": research_software,
+        "featured": featured,
+        "catalogue": catalogue_total(),
+        "output_types": output_types,
+    }
+
+
+def render_snapshot(values: dict[str, Any]) -> str:
+    """Render the compact portfolio snapshot table."""
+    total = int(values["projects"])
+    real_data = int(values["real_data"])
+    research_software = int(values["research_software"])
+    return "\n".join(
+        [
+            SNAPSHOT_START,
+            "| Portfolio signal | Current value |",
+            "| :-- | --: |",
+            f'| Manifest-backed public projects | **{total}** |',
+            f'| Substantial outputs | **{values["outputs"]}** |',
+            f'| Case studies | **{values["cases"]} across {values["domains"]} domains** |',
+            f'| Published PyPI packages | **{values["pypi"]}** |',
+            f'| Real-data / empirical projects | **{real_data} / {total} ({100 * real_data / total:.0f}%)** |',
+            f'| Research software / methods | **{research_software} / {total} ({100 * research_software / total:.0f}%)** |',
+            f'| Curated flagship repositories | **{values["featured"]}** |',
+            f'| Curated catalogue entries | **{values["catalogue"]}** |',
+            SNAPSHOT_END,
+        ]
+    )
+
+
+def render_depth(values: dict[str, Any]) -> str:
+    """Render the portfolio-wide research/output depth table."""
+    total = int(values["projects"])
+    real_data = int(values["real_data"])
+    research_software = int(values["research_software"])
+    return "\n".join(
+        [
+            DEPTH_START,
+            "| Measure | Current scope | What it means |",
+            "| :-- | --: | :-- |",
+            f'| Manifest-backed public projects | **{total}** | Projects with explicit category, maturity and evidence metadata |',
+            f'| Substantial outputs | **{values["outputs"]}** | Published software, research programmes, empirical/replication studies, and decision/engineering artifacts |',
+            f'| Published PyPI packages | **{values["pypi"]}** | Verified package releases, not merely package-ready repositories |',
+            f'| Real-data / empirical projects | **{real_data} / {total} ({100 * real_data / total:.0f}%)** | Explicitly classified in the manifest |',
+            f'| Research software / methods | **{research_software} / {total} ({100 * research_software / total:.0f}%)** | Explicitly classified libraries, methods and research tooling |',
+            f'| Case studies | **{values["cases"]} across {values["domains"]} domains** | End-to-end problem → constraints → method → outcome narratives |',
+            f'| Curated flagship projects | **{values["featured"]}** | Reviewer-oriented subset; deliberately not used as the portfolio denominator |',
+            DEPTH_END,
+        ]
+    )
+
+
+def render_outputs(values: dict[str, Any]) -> str:
+    """Render output-class counts from manifest output types."""
+    output_types: Counter[str] = values["output_types"]
+    ordered_types = (
+        "Published research software",
+        "Research and paper programmes",
+        "Empirical and replication studies",
+        "Decision and engineering artifacts",
+    )
+    rows = [OUTPUTS_START, "| Output class | Count |", "| :-- | --: |"]
+    rows.extend(f"| {label} | **{output_types.get(label, 0)}** |" for label in ordered_types)
+    rows.append(OUTPUTS_END)
+    return "\n".join(rows)
+
+
+def render_boundaries(values: dict[str, Any]) -> str:
+    """Render the denominator reference table."""
+    return "\n".join(
+        [
+            BOUNDARIES_START,
+            "| Question | Denominator |",
+            "| :-- | :-- |",
+            f'| What does the serious public portfolio contain? | **{values["projects"]} manifest-backed public projects** |',
+            f'| What inspectable artifacts has it produced? | **{values["outputs"]} output records** |',
+            f'| What can a reviewer inspect end-to-end? | **{values["cases"]} case studies across {values["domains"]} domains** |',
+            f'| How strong are repository controls on the curated front page? | **{values["featured"]} flagship repositories** |',
+            f'| Where is the broad catalogue concentrated? | **{values["catalogue"]} PROJECTS.md entries** |',
+            BOUNDARIES_END,
+        ]
+    )
+
+
+def replace_block(text: str, start: str, end: str, replacement: str) -> str:
+    """Replace exactly one generated marker block."""
+    pattern = re.compile(re.escape(start) + r".*?" + re.escape(end), re.DOTALL)
+    matches = pattern.findall(text)
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one block between {start} and {end}; found {len(matches)}.")
+    return pattern.sub(replacement, text, count=1)
+
+
+def render_statistics(text: str, values: dict[str, Any]) -> str:
+    """Return Statistics Markdown with all generated tables refreshed."""
+    updated = replace_block(text, SNAPSHOT_START, SNAPSHOT_END, render_snapshot(values))
+    updated = replace_block(updated, DEPTH_START, DEPTH_END, render_depth(values))
+    updated = replace_block(updated, OUTPUTS_START, OUTPUTS_END, render_outputs(values))
+    return replace_block(updated, BOUNDARIES_START, BOUNDARIES_END, render_boundaries(values))
+
+
+def main() -> int:
+    """Generate the canonical tables, or fail if the committed page is stale."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("generate", "check"))
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+    values = metrics(manifest)
+    current = STATISTICS_PATH.read_text(encoding="utf-8")
+    expected = render_statistics(current, values)
+
+    if args.command == "generate":
+        STATISTICS_PATH.write_text(expected, encoding="utf-8")
+        return 0
+
+    if current != expected:
+        print("ERROR: STATISTICS.md generated tables are stale.")
+        return 1
+
+    print("Statistics tables are consistent with canonical portfolio data.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Harden the Statistics tab after the presentation refresh by making its repeated numerical tables derive from the same canonical sources as the existing widgets.

### Changes
- add `scripts/sync_statistics.py`
- derive project, output, case-study, PyPI, empirical, research-software and flagship counts from `data/portfolio.json`
- derive the 87-entry catalogue total using the same `PROJECTS.md` parser as the topic widget
- mark the Snapshot, research/output depth, output composition and denominator tables as generated blocks
- regenerate those blocks in profile maintenance
- verify them in pull-request integrity CI and include the new script in syntax checks

### Scope
- no current statistic changes in this PR
- no existing widget is removed or replaced
- the profile-view counter remains on `STATISTICS.md`
- delivered-impact figures remain human-maintained because they are professional outcomes rather than manifest-derived repository data

The goal is to prevent the Markdown tables from silently drifting away from the generated dashboards when the portfolio manifest changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Statistics tab's numerical tables derive from the same canonical data as the existing widgets, preventing silent drift between the Markdown and the dashboards.

- Adds `scripts/sync_statistics.py` to generate four tables from `data/portfolio.json` and `PROJECTS.md`.
- Marks the Snapshot, depth, output composition, and denominator tables as generated blocks.
- Runs the new script in profile maintenance and verifies it in pull-request integrity CI.
- No statistics values change in this PR; delivered-impact figures remain human-maintained.

<sup>Written for commit e9a375a853e80b351661b29de32b398877d0e28b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

