### PR TITLE
Synchronize flagship engineering controls

### DIFF
--- a/.github/workflows/profile-integrity.yml
+++ b/.github/workflows/profile-integrity.yml
@@ -35,6 +35,11 @@ jobs:
           python scripts/profile_maintenance.py check
           python scripts/sync_statistics.py check
 
+      - name: Validate flagship engineering controls
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/generate_portfolio_metrics.py check
+
       - name: Check public GitHub and PyPI inventory
         run: python scripts/check_external_inventory.py
 

--- a/.github/workflows/profile-maintenance.yml
+++ b/.github/workflows/profile-maintenance.yml
@@ -59,12 +59,15 @@ jobs:
       - name: Regenerate flagship engineering controls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python scripts/generate_portfolio_metrics.py
+        run: python scripts/generate_portfolio_metrics.py generate
 
       - name: Validate generated state
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/profile_maintenance.py check
           python scripts/sync_statistics.py check
+          python scripts/generate_portfolio_metrics.py check
 
       - name: Commit refreshed profile artifacts
         run: |

--- a/STATISTICS.md
+++ b/STATISTICS.md
@@ -97,13 +97,15 @@ Professional outcomes are kept separate from repository metrics because GitHub a
 
 Current structural evidence across those 12 flagships:
 
+<!-- statistics:controls:start -->
 | Control | Coverage |
 | :-- | --: |
 | CI workflow present | **12 / 12 (100%)** |
 | Automated-test marker present | **12 / 12 (100%)** |
-| Dedicated documentation | **11 / 12 (92%)** |
+| Dedicated documentation | **12 / 12 (100%)** |
 | Citation / archive metadata | **10 / 12 (83%)** |
 | Reproducibility-style assets | **8 / 12 (67%)** |
+<!-- statistics:controls:end -->
 
 These are **structural controls**, not claims that every project is scientifically valid or production-ready. A test directory proves that tests exist, not that every possible failure mode is covered.
 

--- a/assets/portfolio-evidence.svg
+++ b/assets/portfolio-evidence.svg
@@ -32,11 +32,11 @@ text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#c9
 <text x="42" y="408" class="note">experiments/results/data/config-style artifacts present</text>
 <rect x="464" y="326" width="420" height="104" rx="10" class="card"/>
 <text x="482" y="353" class="label">Real-data / empirical</text>
-<text x="482" y="385" class="value">4/12 · 33%</text>
-<text x="482" y="408" class="note">explicit curated classification; never inferred from filenames</text>
+<text x="482" y="385" class="value">6/12 · 50%</text>
+<text x="482" y="408" class="note">canonical manifest classification for the curated flagship set</text>
 <rect x="24" y="450" width="420" height="104" rx="10" class="card"/>
 <text x="42" y="477" class="label">Research software / methods</text>
-<text x="42" y="509" class="value">4/12 · 33%</text>
-<text x="42" y="532" class="note">explicit flagship classification</text>
-<text x="24" y="610" class="sub">Generated from FEATURED.md + GitHub repository structure. Semantic classifications are explicit in scripts/generate_portfolio_metrics.py.</text>
+<text x="42" y="509" class="value">5/12 · 42%</text>
+<text x="42" y="532" class="note">canonical manifest classification for the curated flagship set</text>
+<text x="24" y="610" class="sub">Generated from FEATURED.md + GitHub repository structure + canonical manifest classifications.</text>
 </svg>

--- a/scripts/generate_portfolio_metrics.py
+++ b/scripts/generate_portfolio_metrics.py
@@ -1,13 +1,8 @@
-"""Generate evidence-based portfolio metrics for the profile statistics page.
-
-The generator audits the repositories listed in FEATURED.md using the GitHub
-Contents API. Mechanical metrics are discovered from repository structure.
-Semantic metrics that cannot be inferred safely from filenames are maintained
-in an explicit, reviewable manifest below.
-"""
+"""Generate evidence-based flagship metrics for the profile Statistics page."""
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
@@ -15,35 +10,17 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Any, Final
 from xml.sax.saxutils import escape
 
 OWNER: Final[str] = "DiogoRibeiro7"
 FEATURED_PATH: Final[Path] = Path("FEATURED.md")
+MANIFEST_PATH: Final[Path] = Path("data/portfolio.json")
+STATISTICS_PATH: Final[Path] = Path("STATISTICS.md")
 OUTPUT_PATH: Final[Path] = Path("assets/portfolio-evidence.svg")
 API_ROOT: Final[str] = "https://api.github.com"
-
-# These classifications require scientific judgement and are therefore
-# explicit rather than guessed from filenames.
-REAL_DATA_OR_EMPIRICAL: Final[frozenset[str]] = frozenset(
-    {
-        "qwen-text2sql-lab",
-        "clinic-forecasting-platform",
-        "transaction-risk-lakehouse",
-        "oisst-fourier-neural-operator",
-        "portugal-public-pension-financing",
-        "short-rate-anomaly-regimes",
-    }
-)
-
-RESEARCH_SOFTWARE_OR_METHOD_PACKAGE: Final[frozenset[str]] = frozenset(
-    {
-        "genSurvPy",
-        "setqca-python",
-        "behavioral-sensing-research",
-        "bmssp",
-    }
-)
+CONTROLS_START: Final[str] = "<!-- statistics:controls:start -->"
+CONTROLS_END: Final[str] = "<!-- statistics:controls:end -->"
 
 
 @dataclass(frozen=True)
@@ -56,6 +33,20 @@ class RepoEvidence:
     has_docs: bool
     has_citation: bool
     has_reproducibility_assets: bool
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """Complete flagship audit used by both Markdown and SVG outputs."""
+
+    repositories: tuple[str, ...]
+    evidence: tuple[RepoEvidence, ...]
+    real_data_count: int
+    research_software_count: int
+
+    @property
+    def total(self) -> int:
+        return len(self.repositories)
 
 
 def _headers() -> dict[str, str]:
@@ -103,14 +94,27 @@ def _names(entries: list[dict[str, object]]) -> set[str]:
 
 
 def _featured_repos() -> list[str]:
-    """Parse public GitHub repository names from the flagship table."""
+    """Parse the twelve curated repositories from FEATURED.md."""
     text = FEATURED_PATH.read_text(encoding="utf-8")
     matches = re.findall(r"https://github\.com/DiogoRibeiro7/([^/)#]+)", text)
-    excluded = {"diogoribeiro7"}
-    repos = list(dict.fromkeys(repo for repo in matches if repo not in excluded))
+    repos = list(dict.fromkeys(repo for repo in matches if repo != "diogoribeiro7"))
     if len(repos) != 12:
         raise ValueError(f"Expected 12 flagship repositories, found {len(repos)}: {repos}")
     return repos
+
+
+def _project_metadata() -> dict[str, dict[str, Any]]:
+    """Load semantic project classifications from the canonical manifest."""
+    payload: object = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("projects"), list):
+        raise TypeError("Portfolio manifest must contain a projects list.")
+
+    metadata: dict[str, dict[str, Any]] = {}
+    for project in payload["projects"]:
+        if not isinstance(project, dict) or not isinstance(project.get("repo"), str):
+            raise TypeError("Every manifest project must be an object with a string repo field.")
+        metadata[project["repo"]] = project
+    return metadata
 
 
 def _audit_repo(repo: str) -> RepoEvidence:
@@ -144,14 +148,59 @@ def _audit_repo(repo: str) -> RepoEvidence:
     )
 
 
+def audit() -> AuditResult:
+    """Run the full structural and semantic audit over the curated flagship set."""
+    repos = _featured_repos()
+    metadata = _project_metadata()
+    missing = [repo for repo in repos if repo not in metadata]
+    if missing:
+        raise ValueError(f"Featured repositories missing from canonical manifest: {missing}")
+
+    evidence = tuple(_audit_repo(repo) for repo in repos)
+    real_data_count = sum(bool(metadata[repo].get("real_data")) for repo in repos)
+    research_software_count = sum(bool(metadata[repo].get("research_software")) for repo in repos)
+    return AuditResult(tuple(repos), evidence, real_data_count, research_software_count)
+
+
+def _coverage(count: int, total: int) -> str:
+    """Format a count and percentage for Markdown."""
+    return f"{count} / {total} ({100 * count / total:.0f}%)"
+
+
 def _metric(label: str, count: int, total: int, note: str) -> tuple[str, str, str]:
-    """Format one metric tuple for rendering."""
-    pct = 100.0 * count / total
-    return label, f"{count}/{total} · {pct:.0f}%", note
+    """Format one metric tuple for SVG rendering."""
+    return label, f"{count}/{total} · {100 * count / total:.0f}%", note
 
 
-def _render_svg(metrics: list[tuple[str, str, str]], total: int) -> str:
-    """Render a compact dark/light-compatible SVG metrics dashboard."""
+def _metrics(result: AuditResult) -> list[tuple[str, int, str]]:
+    """Return all dashboard metrics from one audit result."""
+    evidence = result.evidence
+    return [
+        ("CI-backed", sum(item.has_ci for item in evidence), "GitHub Actions workflow present"),
+        ("Automated tests", sum(item.has_tests for item in evidence), "tests/test/pytest/tox marker present"),
+        ("Dedicated documentation", sum(item.has_docs for item in evidence), "docs directory or docs config present"),
+        ("Citable / archived", sum(item.has_citation for item in evidence), "CITATION.cff or Zenodo metadata present"),
+        (
+            "Reproducibility assets",
+            sum(item.has_reproducibility_assets for item in evidence),
+            "experiments/results/data/config-style artifacts present",
+        ),
+        (
+            "Real-data / empirical",
+            result.real_data_count,
+            "canonical manifest classification for the curated flagship set",
+        ),
+        (
+            "Research software / methods",
+            result.research_software_count,
+            "canonical manifest classification for the curated flagship set",
+        ),
+    ]
+
+
+def _render_svg(result: AuditResult) -> str:
+    """Render the dark/light-compatible flagship evidence dashboard."""
+    metrics = [_metric(label, count, result.total, note) for label, count, note in _metrics(result)]
     width = 900
     card_w = 420
     card_h = 104
@@ -162,7 +211,7 @@ def _render_svg(metrics: list[tuple[str, str, str]], total: int) -> str:
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
         '<title id="title">Flagship portfolio evidence metrics</title>',
-        f'<desc id="desc">Evidence metrics computed across {total} flagship repositories.</desc>',
+        f'<desc id="desc">Evidence metrics computed across {result.total} flagship repositories.</desc>',
         '<style>',
         'text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#c9d1d9}',
         '.title{font-size:24px;font-weight:700}.sub{font-size:13px;fill:#8b949e}',
@@ -171,7 +220,7 @@ def _render_svg(metrics: list[tuple[str, str, str]], total: int) -> str:
         '</style>',
         '<rect width="100%" height="100%" rx="12" fill="#0d1117"/>',
         '<text x="24" y="34" class="title">Flagship portfolio evidence</text>',
-        f'<text x="24" y="58" class="sub">Audited across {total} featured repositories · structural signals, not popularity metrics</text>',
+        f'<text x="24" y="58" class="sub">Audited across {result.total} featured repositories · structural signals, not popularity metrics</text>',
     ]
 
     for index, (label, value, note) in enumerate(metrics):
@@ -189,46 +238,77 @@ def _render_svg(metrics: list[tuple[str, str, str]], total: int) -> str:
         )
 
     parts.append(
-        f'<text x="24" y="{height - 18}" class="sub">Generated from FEATURED.md + GitHub repository structure. Semantic classifications are explicit in scripts/generate_portfolio_metrics.py.</text>'
+        f'<text x="24" y="{height - 18}" class="sub">Generated from FEATURED.md + GitHub repository structure + canonical manifest classifications.</text>'
     )
     parts.append("</svg>")
     return "\n".join(parts) + "\n"
 
 
-def main() -> None:
-    """Audit the flagship set and write the portfolio evidence SVG."""
-    repos = _featured_repos()
-    evidence = [_audit_repo(repo) for repo in repos]
-    total = len(evidence)
-
-    metrics = [
-        _metric("CI-backed", sum(item.has_ci for item in evidence), total, "GitHub Actions workflow present"),
-        _metric("Automated tests", sum(item.has_tests for item in evidence), total, "tests/test/pytest/tox marker present"),
-        _metric("Dedicated documentation", sum(item.has_docs for item in evidence), total, "docs directory or docs config present"),
-        _metric("Citable / archived", sum(item.has_citation for item in evidence), total, "CITATION.cff or Zenodo metadata present"),
-        _metric(
-            "Reproducibility assets",
-            sum(item.has_reproducibility_assets for item in evidence),
-            total,
-            "experiments/results/data/config-style artifacts present",
-        ),
-        _metric(
-            "Real-data / empirical",
-            len(REAL_DATA_OR_EMPIRICAL & set(repos)),
-            total,
-            "explicit curated classification; never inferred from filenames",
-        ),
-        _metric(
-            "Research software / methods",
-            len(RESEARCH_SOFTWARE_OR_METHOD_PACKAGE & set(repos)),
-            total,
-            "explicit flagship classification",
-        ),
+def _render_controls_table(result: AuditResult) -> str:
+    """Render the Statistics-page engineering-control table from the same audit."""
+    evidence = result.evidence
+    rows = [
+        CONTROLS_START,
+        "| Control | Coverage |",
+        "| :-- | --: |",
+        f'| CI workflow present | **{_coverage(sum(item.has_ci for item in evidence), result.total)}** |',
+        f'| Automated-test marker present | **{_coverage(sum(item.has_tests for item in evidence), result.total)}** |',
+        f'| Dedicated documentation | **{_coverage(sum(item.has_docs for item in evidence), result.total)}** |',
+        f'| Citation / archive metadata | **{_coverage(sum(item.has_citation for item in evidence), result.total)}** |',
+        f'| Reproducibility-style assets | **{_coverage(sum(item.has_reproducibility_assets for item in evidence), result.total)}** |',
+        CONTROLS_END,
     ]
+    return "\n".join(rows)
 
+
+def _replace_controls(text: str, replacement: str) -> str:
+    """Replace exactly one generated engineering-control block."""
+    pattern = re.compile(re.escape(CONTROLS_START) + r".*?" + re.escape(CONTROLS_END), re.DOTALL)
+    matches = pattern.findall(text)
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one engineering-control block; found {len(matches)}.")
+    return pattern.sub(replacement, text, count=1)
+
+
+def _expected_statistics(result: AuditResult) -> str:
+    """Return Statistics Markdown with the flagship control table refreshed."""
+    current = STATISTICS_PATH.read_text(encoding="utf-8")
+    return _replace_controls(current, _render_controls_table(result))
+
+
+def generate(result: AuditResult) -> None:
+    """Write both audit-derived outputs."""
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT_PATH.write_text(_render_svg(metrics, total), encoding="utf-8")
+    OUTPUT_PATH.write_text(_render_svg(result), encoding="utf-8")
+    STATISTICS_PATH.write_text(_expected_statistics(result), encoding="utf-8")
+
+
+def check(result: AuditResult) -> int:
+    """Fail when either committed audit-derived output is stale."""
+    errors: list[str] = []
+    if OUTPUT_PATH.read_text(encoding="utf-8") != _render_svg(result):
+        errors.append("assets/portfolio-evidence.svg is stale")
+    if STATISTICS_PATH.read_text(encoding="utf-8") != _expected_statistics(result):
+        errors.append("STATISTICS.md flagship engineering-control table is stale")
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Flagship engineering controls are synchronized with the current audit.")
+    return 0
+
+
+def main() -> int:
+    """Generate audit outputs or verify their committed state."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("generate", "check"), nargs="?", default="generate")
+    args = parser.parse_args()
+    result = audit()
+    if args.command == "generate":
+        generate(result)
+        return 0
+    return check(result)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Close the remaining Statistics consistency gap by making the flagship engineering-control table and SVG come from one audit result.

### Fixes
- update the structural table to the current curated Featured set
  - CI: 12/12
  - tests: 12/12
  - documentation: 12/12
  - citation/archive metadata: 10/12
  - reproducibility assets: 8/12
- replace stale hard-coded semantic sets in `generate_portfolio_metrics.py`
- derive semantic classifications for the actual 12 Featured repositories from `data/portfolio.json`
  - real-data / empirical: 6/12
  - research software / methods: 5/12
- generate the Markdown engineering-control table and `assets/portfolio-evidence.svg` from the same audit
- add a check mode so CI fails if either committed output is stale
- run that check in both pull-request integrity and post-merge profile maintenance

No widgets are removed. The profile-view counter remains on Statistics and no portfolio-wide denominator changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the engineering-control consistency gap by deriving both the Statistics table and the evidence SVG from a single audit result.

**Bug Fixes**
- Updates the structural table to the current curated Featured set: CI, tests, and documentation are now 12/12, citation/archive 10/12, reproducibility 8/12.
- Replaces hard-coded semantic sets in `generate_portfolio_metrics.py` with classifications from `data/portfolio.json`.
- Generates the Markdown table and SVG from the same audit, so they can't drift.
- Adds a `check` mode that fails CI if either committed output is stale, run in both pull-request and post-merge workflows.
- No widgets are removed; the profile-view counter stays on Statistics and the denominator remains 12.

<sup>Written for commit 1b9dc064560c8154ff3b4e64a613451d9424e146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

