### PR TITLE
Use curated Featured page for flagship counts

### DIFF
--- a/assets/portfolio-overview.svg
+++ b/assets/portfolio-overview.svg
@@ -37,7 +37,7 @@ text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;fill:#c9
 <rect x="24" y="322" width="278" height="102" rx="10" class="card"/>
 <text x="40" y="347" class="label">Curated flagships</text>
 <text x="40" y="379" class="value">12</text>
-<text x="40" y="402" class="note">reviewer-oriented subset, not the main denominator</text>
+<text x="40" y="402" class="note">reviewer-oriented subset from FEATURED.md</text>
 <text x="24" y="458" class="label">Maturity mix</text>
 <text x="24" y="479" class="sub">Counts are mutually exclusive manifest labels; topic and maturity are separate dimensions.</text>
 <text x="24" y="514" class="maturity">published software</text>

--- a/scripts/generate_portfolio_overview.py
+++ b/scripts/generate_portfolio_overview.py
@@ -1,22 +1,37 @@
-"""Generate portfolio-wide statistics from the canonical manifest."""
+"""Generate portfolio-wide statistics from canonical portfolio sources."""
 
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from xml.sax.saxutils import escape
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "data" / "portfolio.json"
+FEATURED = ROOT / "FEATURED.md"
 OUTPUT = ROOT / "assets" / "portfolio-overview.svg"
+FEATURED_REPO_PATTERN = re.compile(r"https://github\.com/DiogoRibeiro7/([^/)#]+)")
 
 
 def load_manifest() -> dict:
+    """Load the canonical portfolio manifest."""
     return json.loads(MANIFEST.read_text(encoding="utf-8"))
 
 
+def featured_total() -> int:
+    """Count the human-curated repositories listed in FEATURED.md."""
+    text = FEATURED.read_text(encoding="utf-8")
+    matches = FEATURED_REPO_PATTERN.findall(text)
+    repos = list(dict.fromkeys(repo for repo in matches if repo != "diogoribeiro7"))
+    if len(repos) != 12:
+        raise ValueError(f"Expected 12 curated Featured repositories, found {len(repos)}: {repos}")
+    return len(repos)
+
+
 def render(manifest: dict) -> str:
+    """Render the portfolio-wide SVG dashboard."""
     projects = manifest["projects"]
     outputs = manifest["outputs"]
     cases = manifest["case_studies"]
@@ -24,7 +39,7 @@ def render(manifest: dict) -> str:
     real_data = sum(bool(p.get("real_data")) for p in projects)
     research_software = sum(bool(p.get("research_software")) for p in projects)
     pypi = sum(bool(p.get("pypi")) for p in projects)
-    featured = sum(bool(p.get("featured")) for p in projects)
+    featured = featured_total()
     domains = len({c["domain"] for c in cases})
     maturity = Counter(p["maturity"] for p in projects)
 
@@ -35,7 +50,7 @@ def render(manifest: dict) -> str:
         ("Real-data / empirical", f"{real_data}/{total} · {100 * real_data / total:.0f}%", "explicit manifest classification"),
         ("Research software / methods", f"{research_software}/{total} · {100 * research_software / total:.0f}%", "explicit manifest classification"),
         ("Published PyPI packages", str(pypi), "verified package releases"),
-        ("Curated flagships", str(featured), "reviewer-oriented subset, not the main denominator"),
+        ("Curated flagships", str(featured), "reviewer-oriented subset from FEATURED.md"),
     ]
 
     maturity_order = [
@@ -110,6 +125,7 @@ def render(manifest: dict) -> str:
 
 
 def main() -> None:
+    """Write the portfolio-wide statistics SVG."""
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(render(load_manifest()), encoding="utf-8")
 

--- a/scripts/sync_statistics.py
+++ b/scripts/sync_statistics.py
@@ -14,7 +14,9 @@ from generate_topic_statistics import count_topics
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "data" / "portfolio.json"
 PROJECTS_PATH = ROOT / "PROJECTS.md"
+FEATURED_PATH = ROOT / "FEATURED.md"
 STATISTICS_PATH = ROOT / "STATISTICS.md"
+FEATURED_REPO_PATTERN = re.compile(r"https://github\.com/DiogoRibeiro7/([^/)#]+)")
 
 SNAPSHOT_START = "<!-- statistics:snapshot:start -->"
 SNAPSHOT_END = "<!-- statistics:snapshot:end -->"
@@ -40,12 +42,21 @@ def load_manifest() -> dict[str, Any]:
 def catalogue_total() -> int:
     """Count curated catalogue entries using the same parser as the topic widget."""
     markdown = PROJECTS_PATH.read_text(encoding="utf-8")
-    counts = count_topics(markdown)
-    return sum(counts.values())
+    return sum(count_topics(markdown).values())
+
+
+def featured_total() -> int:
+    """Count the human-curated repositories listed in FEATURED.md."""
+    text = FEATURED_PATH.read_text(encoding="utf-8")
+    matches = FEATURED_REPO_PATTERN.findall(text)
+    repos = list(dict.fromkeys(repo for repo in matches if repo != "diogoribeiro7"))
+    if len(repos) != 12:
+        raise ValueError(f"Expected 12 curated Featured repositories, found {len(repos)}: {repos}")
+    return len(repos)
 
 
 def metrics(manifest: dict[str, Any]) -> dict[str, Any]:
-    """Derive all Statistics-page counts from canonical sources."""
+    """Derive all Statistics-page counts from their canonical sources."""
     projects = manifest["projects"]
     outputs = manifest["outputs"]
     cases = manifest["case_studies"]
@@ -57,7 +68,6 @@ def metrics(manifest: dict[str, Any]) -> dict[str, Any]:
     real_data = sum(bool(project.get("real_data")) for project in projects)
     research_software = sum(bool(project.get("research_software")) for project in projects)
     pypi = sum(bool(project.get("pypi")) for project in projects)
-    featured = sum(bool(project.get("featured")) for project in projects)
     domains = len({case["domain"] for case in cases})
     output_types = Counter(str(item["type"]) for item in outputs)
 
@@ -69,7 +79,7 @@ def metrics(manifest: dict[str, Any]) -> dict[str, Any]:
         "pypi": pypi,
         "real_data": real_data,
         "research_software": research_software,
-        "featured": featured,
+        "featured": featured_total(),
         "catalogue": catalogue_total(),
         "output_types": output_types,
     }
@@ -80,22 +90,20 @@ def render_snapshot(values: dict[str, Any]) -> str:
     total = int(values["projects"])
     real_data = int(values["real_data"])
     research_software = int(values["research_software"])
-    return "\n".join(
-        [
-            SNAPSHOT_START,
-            "| Portfolio signal | Current value |",
-            "| :-- | --: |",
-            f'| Manifest-backed public projects | **{total}** |',
-            f'| Substantial outputs | **{values["outputs"]}** |',
-            f'| Case studies | **{values["cases"]} across {values["domains"]} domains** |',
-            f'| Published PyPI packages | **{values["pypi"]}** |',
-            f'| Real-data / empirical projects | **{real_data} / {total} ({100 * real_data / total:.0f}%)** |',
-            f'| Research software / methods | **{research_software} / {total} ({100 * research_software / total:.0f}%)** |',
-            f'| Curated flagship repositories | **{values["featured"]}** |',
-            f'| Curated catalogue entries | **{values["catalogue"]}** |',
-            SNAPSHOT_END,
-        ]
-    )
+    return "\n".join([
+        SNAPSHOT_START,
+        "| Portfolio signal | Current value |",
+        "| :-- | --: |",
+        f'| Manifest-backed public projects | **{total}** |',
+        f'| Substantial outputs | **{values["outputs"]}** |',
+        f'| Case studies | **{values["cases"]} across {values["domains"]} domains** |',
+        f'| Published PyPI packages | **{values["pypi"]}** |',
+        f'| Real-data / empirical projects | **{real_data} / {total} ({100 * real_data / total:.0f}%)** |',
+        f'| Research software / methods | **{research_software} / {total} ({100 * research_software / total:.0f}%)** |',
+        f'| Curated flagship repositories | **{values["featured"]}** |',
+        f'| Curated catalogue entries | **{values["catalogue"]}** |',
+        SNAPSHOT_END,
+    ])
 
 
 def render_depth(values: dict[str, Any]) -> str:
@@ -103,21 +111,19 @@ def render_depth(values: dict[str, Any]) -> str:
     total = int(values["projects"])
     real_data = int(values["real_data"])
     research_software = int(values["research_software"])
-    return "\n".join(
-        [
-            DEPTH_START,
-            "| Measure | Current scope | What it means |",
-            "| :-- | --: | :-- |",
-            f'| Manifest-backed public projects | **{total}** | Projects with explicit category, maturity and evidence metadata |',
-            f'| Substantial outputs | **{values["outputs"]}** | Published software, research programmes, empirical/replication studies, and decision/engineering artifacts |',
-            f'| Published PyPI packages | **{values["pypi"]}** | Verified package releases, not merely package-ready repositories |',
-            f'| Real-data / empirical projects | **{real_data} / {total} ({100 * real_data / total:.0f}%)** | Explicitly classified in the manifest |',
-            f'| Research software / methods | **{research_software} / {total} ({100 * research_software / total:.0f}%)** | Explicitly classified libraries, methods and research tooling |',
-            f'| Case studies | **{values["cases"]} across {values["domains"]} domains** | End-to-end problem → constraints → method → outcome narratives |',
-            f'| Curated flagship projects | **{values["featured"]}** | Reviewer-oriented subset; deliberately not used as the portfolio denominator |',
-            DEPTH_END,
-        ]
-    )
+    return "\n".join([
+        DEPTH_START,
+        "| Measure | Current scope | What it means |",
+        "| :-- | --: | :-- |",
+        f'| Manifest-backed public projects | **{total}** | Projects with explicit category, maturity and evidence metadata |',
+        f'| Substantial outputs | **{values["outputs"]}** | Published software, research programmes, empirical/replication studies, and decision/engineering artifacts |',
+        f'| Published PyPI packages | **{values["pypi"]}** | Verified package releases, not merely package-ready repositories |',
+        f'| Real-data / empirical projects | **{real_data} / {total} ({100 * real_data / total:.0f}%)** | Explicitly classified in the manifest |',
+        f'| Research software / methods | **{research_software} / {total} ({100 * research_software / total:.0f}%)** | Explicitly classified libraries, methods and research tooling |',
+        f'| Case studies | **{values["cases"]} across {values["domains"]} domains** | End-to-end problem → constraints → method → outcome narratives |',
+        f'| Curated flagship projects | **{values["featured"]}** | Reviewer-oriented subset; deliberately not used as the portfolio denominator |',
+        DEPTH_END,
+    ])
 
 
 def render_outputs(values: dict[str, Any]) -> str:
@@ -137,19 +143,17 @@ def render_outputs(values: dict[str, Any]) -> str:
 
 def render_boundaries(values: dict[str, Any]) -> str:
     """Render the denominator reference table."""
-    return "\n".join(
-        [
-            BOUNDARIES_START,
-            "| Question | Denominator |",
-            "| :-- | :-- |",
-            f'| What does the serious public portfolio contain? | **{values["projects"]} manifest-backed public projects** |',
-            f'| What inspectable artifacts has it produced? | **{values["outputs"]} output records** |',
-            f'| What can a reviewer inspect end-to-end? | **{values["cases"]} case studies across {values["domains"]} domains** |',
-            f'| How strong are repository controls on the curated front page? | **{values["featured"]} flagship repositories** |',
-            f'| Where is the broad catalogue concentrated? | **{values["catalogue"]} PROJECTS.md entries** |',
-            BOUNDARIES_END,
-        ]
-    )
+    return "\n".join([
+        BOUNDARIES_START,
+        "| Question | Denominator |",
+        "| :-- | :-- |",
+        f'| What does the serious public portfolio contain? | **{values["projects"]} manifest-backed public projects** |',
+        f'| What inspectable artifacts has it produced? | **{values["outputs"]} output records** |',
+        f'| What can a reviewer inspect end-to-end? | **{values["cases"]} case studies across {values["domains"]} domains** |',
+        f'| How strong are repository controls on the curated front page? | **{values["featured"]} flagship repositories** |',
+        f'| Where is the broad catalogue concentrated? | **{values["catalogue"]} PROJECTS.md entries** |',
+        BOUNDARIES_END,
+    ])
 
 
 def replace_block(text: str, start: str, end: str, replacement: str) -> str:
@@ -175,8 +179,7 @@ def main() -> int:
     parser.add_argument("command", choices=("generate", "check"))
     args = parser.parse_args()
 
-    manifest = load_manifest()
-    values = metrics(manifest)
+    values = metrics(load_manifest())
     current = STATISTICS_PATH.read_text(encoding="utf-8")
     expected = render_statistics(current, values)
 


### PR DESCRIPTION
## Summary

Remove the final dependency on stale manifest `featured` flags now that `FEATURED.md` is the editorial source of truth.

### Changes
- make `scripts/sync_statistics.py` count curated flagships from `FEATURED.md`
- make `scripts/generate_portfolio_overview.py` use the same curated Featured count
- validate that the Featured page still contains exactly 12 unique repositories
- refresh the overview widget note to state that the flagship subset comes from `FEATURED.md`

### Scope
- no displayed count changes: the value remains 12
- no widget is removed
- no portfolio-wide denominator changes
- old manifest `featured` flags may remain as legacy metadata, but Statistics no longer relies on them

After this change, every Statistics use of the flagship set is anchored to the actual curated Featured page rather than obsolete manifest flags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the final dependency on stale manifest `featured` flags by counting curated flagships from `FEATURED.md` in both statistics and the overview dashboard.

- `scripts/sync_statistics.py` and `scripts/generate_portfolio_overview.py` now parse `FEATURED.md` for the flagship count instead of summing manifest flags.
- Both scripts validate that `FEATURED.md` lists exactly 12 unique repositories, failing otherwise.
- The overview dashboard note now states the flagship subset comes from `FEATURED.md`.
- The displayed count stays 12; no widgets are removed and the portfolio-wide denominator is unchanged.
- Legacy manifest `featured` flags remain as metadata but are no longer used by Statistics.

<sup>Written for commit 27d3733b51a481869e9739e1d71a99b90c9acd3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/diogoribeiro7/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

